### PR TITLE
fix: panels error/loop when no database is open

### DIFF
--- a/frontend/src/__tests__/CommentPanel.reactivity.test.js
+++ b/frontend/src/__tests__/CommentPanel.reactivity.test.js
@@ -1,0 +1,47 @@
+/**
+ * CommentPanel.reactivity.test.js
+ *
+ * Regression: opening the comments tab with no database open (the displayed
+ * position has id 0) used to throw `effect_update_depth_exceeded`. The mount
+ * effect called loadComments(), whose no-DB branch ran synchronously (no await)
+ * and both wrote and read `allComments` in the same pass — making the effect
+ * read-and-write the same state, an infinite update loop. displayedComments is
+ * now owned solely by the search $effect, so loadComments only writes
+ * allComments. See CommentPanel.svelte.
+ */
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/svelte';
+import { tick } from 'svelte';
+
+vi.mock('../../wailsjs/go/database/Database.js', () => ({
+    GetCommentsByPosition: vi.fn(() => Promise.resolve([])),
+    SearchComments: vi.fn(() => Promise.resolve([])),
+    LoadAnalysis: vi.fn(() => Promise.resolve(null)),
+    LoadPosition: vi.fn(() => Promise.resolve(null)),
+    AddComment: vi.fn(() => Promise.resolve()),
+    UpdateCommentEntry: vi.fn(() => Promise.resolve()),
+    DeleteCommentEntry: vi.fn(() => Promise.resolve())
+}));
+
+import CommentPanel from '../components/CommentPanel.svelte';
+
+afterEach(cleanup);
+
+describe('CommentPanel — no infinite effect loop on mount', () => {
+    test('mounts with no database open without an update-depth loop', async () => {
+        // Svelte logs the infinite-loop error via console.error; spy on it.
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        try {
+            render(CommentPanel, { props: { visible: true, onClose: () => {} } });
+            await tick();
+            await tick();
+            await new Promise((r) => setTimeout(r, 50));
+        } finally {
+            spy.mockRestore();
+        }
+        const logged = spy.mock.calls.map((c) => c.join(' '));
+        const loopErr = logged.find((e) => /effect_update_depth_exceeded|update depth/.test(e));
+        expect(loopErr, `console errors: ${logged.join('\n')}`).toBeUndefined();
+    });
+});

--- a/frontend/src/__tests__/MatchPanel.reactivity.test.js
+++ b/frontend/src/__tests__/MatchPanel.reactivity.test.js
@@ -34,6 +34,7 @@ vi.mock('../../wailsjs/go/database/Database.js', () => ({
 import { openPanels, PANEL, matchPanelRefreshTriggerStore } from '../stores/uiStore.js';
 import { lastVisitedMatchStore } from '../stores/positionStore.js';
 import { tournamentsStore } from '../stores/tournamentStore.js';
+import { databasePathStore } from '../stores/databaseStore.js';
 
 // ── DB mock ref (pour vérifier les appels) ────────────────────────────────────
 import { GetAllMatches } from '../../wailsjs/go/database/Database.js';
@@ -43,6 +44,9 @@ import MatchPanel from '../components/MatchPanel.svelte';
 
 // ── Reset stores ─────────────────────────────────────────────────────────────
 function resetStores() {
+    // A database must appear open: MatchPanel only loads when databaseLoadedStore
+    // (derived from a non-empty databasePathStore) is true.
+    databasePathStore.set('/tmp/test.db');
     openPanels.set(new Set());
     matchPanelRefreshTriggerStore.set(0);
     tournamentsStore.set([]);

--- a/frontend/src/__tests__/StatsPanel.reactivity.test.js
+++ b/frontend/src/__tests__/StatsPanel.reactivity.test.js
@@ -40,6 +40,7 @@ vi.mock('../../wailsjs/go/main/Config.js', () => ({
 
 // ── Stores ───────────────────────────────────────────────────────────────────
 import { statsFilterStore, statsResultStore, statsLoadingStore, statsErrorStore, statsMetricStore } from '../stores/statsStore.js';
+import { databasePathStore } from '../stores/databaseStore.js';
 
 // ── DB mock ref (pour compter les appels) ────────────────────────────────────
 import { ComputeStats } from '../../wailsjs/go/database/Database.js';
@@ -59,6 +60,9 @@ const DEFAULT_FILTER = {
 };
 
 function resetStores() {
+    // StatsPanel only refreshes stats when a database is open
+    // (databaseLoadedStore derives from a non-empty databasePathStore).
+    databasePathStore.set('/tmp/test.db');
     statsFilterStore.set({ ...DEFAULT_FILTER });
     statsResultStore.set(null);
     statsLoadingStore.set(false);

--- a/frontend/src/components/CommentPanel.svelte
+++ b/frontend/src/components/CommentPanel.svelte
@@ -39,6 +39,11 @@
     });
 
     async function loadComments() {
+        // Only update allComments here; the search $effect below owns
+        // displayedComments. Reading allComments in the same synchronous effect
+        // pass that writes it (the no-DB / position-id-0 case takes no await,
+        // so it stays synchronous) made the effect read-and-write the same
+        // state, triggering an infinite update loop (effect_update_depth_exceeded).
         try {
             const pos = $positionStore;
             if (pos && pos.id) {
@@ -46,11 +51,9 @@
             } else {
                 allComments = [];
             }
-            if (!searchQuery.trim()) displayedComments = allComments;
         } catch (error) {
             logger.error('Error loading comments:', error);
             allComments = [];
-            displayedComments = [];
         }
     }
 

--- a/frontend/src/components/FilterLibraryPanel.svelte
+++ b/frontend/src/components/FilterLibraryPanel.svelte
@@ -7,6 +7,7 @@
     import { positionStore, positionBeforeFilterLibraryStore, positionIndexBeforeFilterLibraryStore } from '../stores/positionStore';
     import { commandHistoryStore } from '../stores/commandHistoryStore'; // Import command history store
     import { searchHistoryStore } from '../stores/searchHistoryStore'; // Import search history store
+    import { databaseLoadedStore } from '../stores/databaseStore';
     import { t, tMsg } from '../i18n';
 
     let { onLoadPositionsByFilters } = $props();
@@ -29,7 +30,7 @@
         const v = $openPanels.has(PANEL.FILTER_LIBRARY);
         if (v !== _prevVisible) {
             if (v) {
-                loadFilters();
+                if ($databaseLoadedStore) loadFilters();
             } else {
                 if (selectedFilter) {
                     if ($positionBeforeFilterLibraryStore) {

--- a/frontend/src/components/MatchPanel.svelte
+++ b/frontend/src/components/MatchPanel.svelte
@@ -33,10 +33,12 @@
     import { analysisStore, selectedMoveStore } from '../stores/analysisStore';
     import { commentTextStore } from '../stores/uiStore';
     import { tournamentsStore } from '../stores/tournamentStore';
+    import { databaseLoadedStore } from '../stores/databaseStore';
 
     let matches = $state([]);
     let selectedMatch = $state(null);
     const visible = $derived($openPanels.has(PANEL.MATCH));
+    const databaseLoaded = $derived($databaseLoadedStore);
     let lastVisitedMatch = $derived($lastVisitedMatchStore);
     let tournaments = $derived($tournamentsStore || []);
 
@@ -77,7 +79,7 @@
     $effect(() => {
         const trigger = $matchPanelRefreshTriggerStore;
         if (trigger === 0) return; // skip initial run
-        if (untrack(() => !visible)) return;
+        if (untrack(() => !visible || !databaseLoaded)) return;
         loadMatches().then(() => {
             const lvm = lastVisitedMatch;
             if (lvm && lvm.matchID) {
@@ -96,7 +98,7 @@
         const opened = visible; // $derived — tracked
         const wasVisible = _prevVisible;
         _prevVisible = opened;
-        if (opened && !wasVisible) {
+        if (opened && !wasVisible && databaseLoaded) {
             loadMatches().then(() => {
                 const lvm = lastVisitedMatch;
                 if (lvm && lvm.matchID) {

--- a/frontend/src/components/MetadataPanel.svelte
+++ b/frontend/src/components/MetadataPanel.svelte
@@ -3,6 +3,7 @@
     import { onDestroy } from 'svelte';
     import { LoadMetadata, SaveMetadata } from '../../wailsjs/go/database/Database.js';
     import { activeTabStore } from '../stores/uiStore';
+    import { databaseLoadedStore } from '../stores/databaseStore';
     import { t } from '../i18n';
 
     let user = $state('');
@@ -37,7 +38,7 @@
     let wasActive = false;
     $effect(() => {
         const value = $activeTabStore;
-        if (value === 'metadata') {
+        if (value === 'metadata' && $databaseLoadedStore) {
             loadMetadata().then(() => {
                 wasActive = true;
             });

--- a/frontend/src/components/SearchHistoryPanel.svelte
+++ b/frontend/src/components/SearchHistoryPanel.svelte
@@ -4,6 +4,7 @@
     import { searchHistoryStore } from '../stores/searchHistoryStore';
     import { positionStore, positionBeforeFilterLibraryStore, positionIndexBeforeFilterLibraryStore } from '../stores/positionStore';
     import { statusBarTextStore, openPanels, PANEL, closePanel, currentPositionIndexStore } from '../stores/uiStore';
+    import { databaseLoadedStore } from '../stores/databaseStore';
     import { LoadSearchHistory, DeleteSearchHistoryEntry, LoadFilters } from '../../wailsjs/go/database/Database.js';
     import { t, tMsg } from '../i18n';
 
@@ -24,8 +25,10 @@
         const v = $openPanels.has(PANEL.SEARCH_HISTORY);
         if (v !== _prevVisible) {
             if (v) {
-                loadHistory();
-                loadFilterLibrary();
+                if ($databaseLoadedStore) {
+                    loadHistory();
+                    loadFilterLibrary();
+                }
             } else {
                 if (selectedSearch) {
                     if ($positionBeforeFilterLibraryStore) {

--- a/frontend/src/components/SearchPanel.svelte
+++ b/frontend/src/components/SearchPanel.svelte
@@ -8,6 +8,7 @@
     import { searchHistoryStore } from '../stores/searchHistoryStore';
     import { filterLibraryStore } from '../stores/filterLibraryStore';
     import { searchParamsStore } from '../stores/searchParamsStore';
+    import { databaseLoadedStore } from '../stores/databaseStore';
     import { SaveSearchHistory, LoadSearchHistory, DeleteSearchHistoryEntry, LoadFilters, DeleteFilter, LoadEditPosition, LoadExcludePosition } from '../../wailsjs/go/database/Database.js';
 
     let { onLoadPositionsByFilters, onAddToFilterLibrary } = $props();
@@ -309,7 +310,7 @@
         }
     }
     $effect(() => {
-        if ($activeTabStore === 'search') {
+        if ($activeTabStore === 'search' && $databaseLoadedStore) {
             loadHistory();
             loadSavedFilters();
         }

--- a/frontend/src/components/TournamentPanel.svelte
+++ b/frontend/src/components/TournamentPanel.svelte
@@ -24,6 +24,7 @@
     import { positionStore, matchContextStore, lastVisitedMatchStore } from '../stores/positionStore';
     import { analysisStore, selectedMoveStore } from '../stores/analysisStore';
     import { commentTextStore } from '../stores/uiStore';
+    import { databaseLoadedStore } from '../stores/databaseStore';
     import { t, tMsg } from '../i18n';
     import { get } from 'svelte/store';
 
@@ -68,7 +69,7 @@
         const v = $openPanels.has(PANEL.TOURNAMENT);
         if (v !== _prevVisible) {
             if (v) {
-                loadTournaments();
+                if ($databaseLoadedStore) loadTournaments();
                 selectedTournamentStore.set(null);
                 tournamentMatchesStore.set([]);
             } else {

--- a/frontend/src/components/stats/StatsFilterBar.svelte
+++ b/frontend/src/components/stats/StatsFilterBar.svelte
@@ -1,6 +1,8 @@
 <script>
     import { onMount } from 'svelte';
+    import { get } from 'svelte/store';
     import { statsFilterStore, statsMetricStore } from '../../stores/statsStore.js';
+    import { databaseLoadedStore } from '../../stores/databaseStore.js';
     import { GetAllPlayerNames, GetAllTournaments, GetStatsDateRange } from '../../../wailsjs/go/database/Database.js';
     import { GetStatsFilter, SaveStatsFilter } from '../../../wailsjs/go/main/Config.js';
 
@@ -132,7 +134,11 @@
 
     onMount(async () => {
         try {
-            const [players, tournaments, persisted, dateRange] = await Promise.all([GetAllPlayerNames(), GetAllTournaments(), GetStatsFilter(), GetStatsDateRange()]);
+            // Skip the DB-backed lookups when no database is open (they would
+            // otherwise error); the persisted filter still comes from Config.
+            const dbLoaded = get(databaseLoadedStore);
+            const [players, tournaments, dateRange] = dbLoaded ? await Promise.all([GetAllPlayerNames(), GetAllTournaments(), GetStatsDateRange()]) : [[], [], null];
+            const persisted = await GetStatsFilter();
 
             playerList = players ?? [];
             tournamentList = (tournaments ?? []).map((t) => ({ id: t.id, name: t.name }));

--- a/frontend/src/components/stats/StatsPanel.svelte
+++ b/frontend/src/components/stats/StatsPanel.svelte
@@ -2,6 +2,7 @@
     import { logger } from '../../utils/logger.js';
     import { statsFilterStore, statsResultStore, statsLoadingStore, statsMetricStore, statsInvalidationKeyStore, refreshStats } from '../../stores/statsStore.js';
     import { activeTabStore } from '../../stores/uiStore.js';
+    import { databaseLoadedStore } from '../../stores/databaseStore.js';
     import StatsFilterBar from './StatsFilterBar.svelte';
     import StatsDashboardTab from './StatsDashboardTab.svelte';
     import StatsProgressionTab from './StatsProgressionTab.svelte';
@@ -13,6 +14,7 @@
     $effect(() => {
         const filter = $statsFilterStore;
         const key = $statsInvalidationKeyStore;
+        if (!$databaseLoadedStore) return;
         logger.perf('StatsPanel:refreshStats', () => refreshStats(filter, key));
     });
 

--- a/pkg/blunderdb/database/db.go
+++ b/pkg/blunderdb/database/db.go
@@ -68,6 +68,13 @@ func (d *Database) SetupDatabase(path string) error {
 		return err
 	}
 
+	// Size the connection pool. Critical for ":memory:": each pooled
+	// connection is a SEPARATE empty in-memory database, so concurrent reads
+	// (RWMutex allows multiple readers) would otherwise hit a fresh connection
+	// with no schema -> "no such table". ConfigurePool pins ":memory:" to a
+	// single connection; file-backed DBs are allowed to grow.
+	sqlite.ConfigurePool(d.db, path)
+
 	// Apply performance and safety PRAGMAs (includes foreign_keys=ON)
 	if err = d.applyPragmas(path); err != nil {
 		return err
@@ -468,6 +475,13 @@ func (d *Database) OpenDatabase(path string) error {
 	if err != nil {
 		return err
 	}
+
+	// Size the connection pool. Critical for ":memory:": each pooled
+	// connection is a SEPARATE empty in-memory database, so concurrent reads
+	// (RWMutex allows multiple readers) would otherwise hit a fresh connection
+	// with no schema -> "no such table". ConfigurePool pins ":memory:" to a
+	// single connection; file-backed DBs are allowed to grow.
+	sqlite.ConfigurePool(d.db, path)
 
 	// Apply performance and safety PRAGMAs (includes foreign_keys=ON)
 	if err = d.applyPragmas(path); err != nil {

--- a/pkg/blunderdb/database/memory_pool_test.go
+++ b/pkg/blunderdb/database/memory_pool_test.go
@@ -1,0 +1,57 @@
+package database
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestInMemoryConcurrentReadsShareSchema guards against a regression where the
+// in-memory GUI database (SetupDatabase(":memory:")) lost its schema under
+// concurrent reads.
+//
+// Root cause: with database/sql, every pooled connection to ":memory:" is a
+// SEPARATE, empty in-memory database. SetupDatabase creates the schema on one
+// connection, but Database's RWMutex allows multiple concurrent readers, so the
+// pool would open extra connections — each with no tables — yielding
+// "SQL logic error: no such table: match/tournament/search_history". This
+// surfaced in the GUI before any database file was opened, when switching to
+// tabs (matches/tournaments/stats) that fire several Wails queries at once.
+//
+// Fix: ConfigurePool pins ":memory:" to a single connection (db.go).
+func TestInMemoryConcurrentReadsShareSchema(t *testing.T) {
+	d := NewDatabase()
+	if err := d.SetupDatabase(":memory:"); err != nil {
+		t.Fatalf("SetupDatabase(:memory:): %v", err)
+	}
+	t.Cleanup(func() { _ = d.Close() })
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	errs := make(chan error, goroutines*3)
+	for range goroutines {
+		wg.Go(func() {
+			if _, err := d.GetAllMatches(); err != nil {
+				errs <- err
+			}
+			if _, err := d.GetAllTournaments(); err != nil {
+				errs <- err
+			}
+			if _, err := d.LoadSearchHistory(); err != nil {
+				errs <- err
+			}
+		})
+	}
+	wg.Wait()
+	close(errs)
+
+	failures := 0
+	for err := range errs {
+		failures++
+		if failures <= 3 {
+			t.Errorf("concurrent read on in-memory DB failed: %v", err)
+		}
+	}
+	if failures > 0 {
+		t.Errorf("%d concurrent in-memory reads failed (expected 0)", failures)
+	}
+}


### PR DESCRIPTION
Fixes three issues that surface when interacting with the UI **before any database is opened**.

## 1. Comment panel infinite loop (`41c2052c`)
Opening the comments tab with no DB threw `effect_update_depth_exceeded`. The mount effect's `loadComments()` no-DB branch ran synchronously and both wrote and read `allComments` in the same pass (a Svelte 5 read-and-write-same-state loop). `loadComments` now writes only `allComments`; the search `$effect` owns `displayedComments`. Regression test added.

## 2. "no such table" under concurrency (`35e4e7e0`) — root cause
Switching to matches/tournaments/stats with no DB open logged `SQL logic error: no such table: match/tournament/search_history`. With `database/sql`, every pooled connection to `:memory:` is a **separate empty database**. `SetupDatabase(":memory:")` created the schema on one connection, but `Database`'s `RWMutex` allows concurrent readers, so the pool opened extra schemaless connections. The `storage/sqlite` layer already solved this (`ConfigurePool` → `SetMaxOpenConns(1)` for `:memory:`); the `database` package just never called it. Now it does, in `SetupDatabase` and `OpenDatabase`. Concurrent-read regression test added.

## 3. Defensive `databaseLoaded` guards (`07bf4f91`)
Independently, panels that auto-load from the DB on mount/visibility now skip the load until a database is open (`databaseLoadedStore`), matching `CollectionPanel`/`AnkiPanel`: MetadataPanel, SearchPanel, TournamentPanel, SearchHistoryPanel, FilterLibraryPanel, MatchPanel, StatsPanel, StatsFilterBar.

## Verification
- `go vet ./...`, `go test -race -count=1 ./...`, `golangci-lint` (0 issues), `gofmt` — all clean
- Frontend `npm run lint` + `format:check`, 379 vitest tests pass
- Confirmed in `wails dev`: navigating those tabs with no DB open produces zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)