### PR TITLE
feat(search): explicit checker/cube decision-type filter with take/pass sub-type

### DIFF
--- a/frontend/src/components/Board.svelte
+++ b/frontend/src/components/Board.svelte
@@ -8,7 +8,7 @@
     import Two from 'two.js';
     import { get } from 'svelte/store';
     import { statusBarModeStore, isAnyModalOpen, activeModal, MODAL, openPanels, PANEL, showPipcountStore, activeTabStore } from '../stores/uiStore';
-    import { searchStructureModeStore } from '../stores/searchExcludePositionStore';
+    import { searchStructureModeStore, searchOfferedCubeStore } from '../stores/searchExcludePositionStore';
     import { boardColorsStore } from '../stores/boardColorsStore';
 
     // Sentinel colour stored on an exclude-structure point that must hold no checker.
@@ -66,6 +66,7 @@
     let unsubscribe;
     let unsubscribeSelectedMove;
     let unsubscribeAnalysis;
+    let unsubscribeOfferedCube;
     let _isMouseDown = false;
     let startMousePos = null;
     // Manual double-click tracking for the Except "must be empty" marker. Native
@@ -625,6 +626,18 @@
             mouseY <= cubePosition.y + cubePosition.size / 2
         ) {
             positionStore.update((pos) => {
+                // Take/pass search: the cube is an offered (centered) cube. Edit its
+                // value while keeping it centered (owner -1); an offered cube is at
+                // least a double, so value stays ≥ 1 (displayed ≥ 2).
+                if (get(searchOfferedCubeStore) && pos.decision_type === 1) {
+                    if (event.button === 0) {
+                        pos.cube.value = Math.min(pos.cube.value + 1, 6);
+                    } else if (event.button === 2) {
+                        pos.cube.value = Math.max(pos.cube.value - 1, 1);
+                    }
+                    pos.cube.owner = -1;
+                    return pos;
+                }
                 if (pos.cube.owner === -1) {
                     pos.cube.value = Math.min(pos.cube.value + 1, 6);
                     pos.cube.owner = event.button === 0 ? 0 : 1;
@@ -909,6 +922,12 @@
             if (two && canvas) drawBoard();
         });
 
+        // Redraw when the take/pass "offered cube" mode toggles so the cube moves
+        // between its centered (offered) and owner positions immediately.
+        unsubscribeOfferedCube = searchOfferedCubeStore.subscribe(() => {
+            if (two && canvas) drawBoard();
+        });
+
         logCanvasSize();
         window.addEventListener('resize', logCanvasSize);
     });
@@ -929,6 +948,7 @@
         if (unsubscribe) unsubscribe();
         if (unsubscribeSelectedMove) unsubscribeSelectedMove();
         if (unsubscribeAnalysis) unsubscribeAnalysis();
+        if (unsubscribeOfferedCube) unsubscribeOfferedCube();
     });
 
     // Helper function to get the position to display
@@ -1036,6 +1056,10 @@
         // the analysis' recorded played actions.
         const isCubeResponse = (() => {
             if (position.decision_type !== 1) return false;
+            // While editing, the centered "offered cube" is shown only when the
+            // user is explicitly building a take/pass (response) search — never
+            // from stale analysis of a previously viewed position.
+            if (mode === 'EDIT') return get(searchOfferedCubeStore) === true;
             const matchCtx = get(matchContextStore);
             if (matchCtx && matchCtx.isMatchMode && matchCtx.movePositions.length > 0) {
                 const mp = matchCtx.movePositions[matchCtx.currentIndex];

--- a/frontend/src/components/SearchPanel.svelte
+++ b/frontend/src/components/SearchPanel.svelte
@@ -1,10 +1,10 @@
 <script>
     import { logger } from '../utils/logger.js';
     import { t, tMsg } from '../i18n';
-    import { onMount, onDestroy, tick } from 'svelte';
+    import { onMount, onDestroy, tick, untrack } from 'svelte';
     import { statusBarTextStore, currentPositionIndexStore, activeTabStore } from '../stores/uiStore';
     import { positionStore, positionsStore, positionBeforeFilterLibraryStore, positionIndexBeforeFilterLibraryStore } from '../stores/positionStore';
-    import { searchExcludePositionStore, searchStructureModeStore, emptySearchBoardPosition, boardHasCheckers } from '../stores/searchExcludePositionStore';
+    import { searchExcludePositionStore, searchStructureModeStore, searchOfferedCubeStore, emptySearchBoardPosition, boardHasCheckers } from '../stores/searchExcludePositionStore';
     import { searchHistoryStore } from '../stores/searchHistoryStore';
     import { filterLibraryStore } from '../stores/filterLibraryStore';
     import { searchParamsStore } from '../stores/searchParamsStore';
@@ -127,6 +127,13 @@
     let player2JanBlotRangeMin = $state(0);
     let player2JanBlotRangeMax = $state(15);
     let diceRollOption = $state('both'); // 'both' | 'first'
+    // Decision-type filter (Display group). The "Include Decision Type" checkbox is
+    // the on/off ("Indifférent") gate; when on, decisionMode reflects the board
+    // (Pions = checker / Cube = cube decision) and cubeSubType refines a cube
+    // decision into all / double-no-double / take-pass.
+    let decisionMode = $state('checker'); // 'checker' | 'cube' — meaningful while the filter is enabled
+    let cubeSubType = $state('all'); // 'all' | 'double' | 'takepass'
+    let lastCheckerDice = $state([3, 1]); // remembers the roll when toggling Pions ⇄ Cube from the panel
     let creationDateOption = $state('min');
     let creationDateMin = $state('');
     let creationDateMax = $state('');
@@ -273,6 +280,92 @@
         if ($activeTabStore === 'search' && structureMode === 'include') {
             savedSearchPosition = JSON.parse(JSON.stringify($positionStore));
         }
+    });
+
+    // Board → panel: editing the board (placing dice → checker, clicking a player
+    // rectangle → cube) drives the Pions/Cube choice. Only tracks the include board.
+    $effect(() => {
+        const dt = $positionStore?.decision_type === 1 ? 'cube' : 'checker';
+        if ($activeTabStore === 'search' && structureMode === 'include') {
+            untrack(() => {
+                if (decisionMode !== dt) decisionMode = dt;
+            });
+        }
+    });
+
+    // A cube decision has no dice, so the Dice Roll filter is meaningless when the
+    // decision-type filter constrains to a cube decision.
+    $effect(() => {
+        if (filterEnabled['Include Decision Type'] && decisionMode === 'cube') {
+            untrack(() => {
+                filterEnabled['Include Dice Roll'] = false;
+            });
+        }
+    });
+
+    // Panel → board: choosing Pions/Cube edits the include board (and remembers the
+    // last real roll so toggling back to Pions restores it).
+    function selectDecisionMode(mode) {
+        if (structureMode !== 'include') return;
+        positionStore.update((p) => {
+            if (mode === 'cube') {
+                if (p.decision_type !== 1) {
+                    if (Array.isArray(p.dice) && (p.dice[0] || p.dice[1])) {
+                        lastCheckerDice = [p.dice[0], p.dice[1]];
+                    }
+                    p.decision_type = 1;
+                    p.dice = [0, 0];
+                }
+            } else {
+                p.decision_type = 0;
+                if (!Array.isArray(p.dice) || (!p.dice[0] && !p.dice[1])) {
+                    p.dice = [lastCheckerDice[0], lastCheckerDice[1]];
+                }
+            }
+            return p;
+        });
+        decisionMode = mode;
+        if (mode === 'cube' && cubeSubType === 'takepass') applyOfferedCube();
+    }
+
+    // applyOfferedCube turns the board cube into a centered "offered" cube (owner
+    // -1), matching how take/pass positions are stored (the board can't otherwise
+    // build a centered value>1 cube). An offered cube is at least a double.
+    function applyOfferedCube() {
+        if (structureMode !== 'include') return;
+        positionStore.update((p) => {
+            p.decision_type = 1;
+            p.dice = [0, 0];
+            p.cube.owner = -1;
+            if (!p.cube.value || p.cube.value < 1) p.cube.value = 1;
+            return p;
+        });
+    }
+
+    // Panel → cube sub-type. Take/pass needs the board cube rendered/edited as a
+    // centered offered cube; double/all use the normal owner-based cube.
+    function selectCubeSubType(value) {
+        cubeSubType = value;
+        if (value === 'takepass') {
+            applyOfferedCube();
+        } else if (structureMode === 'include') {
+            // Leaving take/pass: reset the offered cube (centered, value > 1) back
+            // to the initial centered 1-cube. An owned cube set in double mode
+            // (owner 0/1) is preserved.
+            positionStore.update((p) => {
+                if (p.cube.owner === -1 && p.cube.value >= 1) {
+                    p.cube.value = 0;
+                }
+                return p;
+            });
+        }
+    }
+
+    // Drive the offered-cube flag the board reads: on only while building a
+    // take/pass query on the include board of the search tab.
+    $effect(() => {
+        const offered = $activeTabStore === 'search' && structureMode === 'include' && !!filterEnabled['Include Decision Type'] && decisionMode === 'cube' && cubeSubType === 'takepass';
+        untrack(() => searchOfferedCubeStore.set(offered));
     });
 
     // restoreExcludeStructure resets the structure editing state to 'include' and
@@ -481,6 +574,13 @@
             }
         });
 
+        // Cube sub-type: when the decision-type filter constrains to a cube
+        // decision, narrow to double/no-double (`dd`) or take/pass (`dr`). The `d`
+        // token already carries the cube decision_type read from the board.
+        if (filterEnabled['Include Decision Type'] && decisionMode === 'cube' && cubeSubType !== 'all') {
+            transformedFilters.push(cubeSubType === 'takepass' ? 'dr' : 'dd');
+        }
+
         const incCube = transformedFilters.includes('cube');
         const incScore = transformedFilters.includes('score');
         const ncFilter = transformedFilters.includes('nc');
@@ -683,6 +783,9 @@
         player2JanBlotRangeMin = 0;
         player2JanBlotRangeMax = 15;
         diceRollOption = 'both';
+        decisionMode = 'checker';
+        cubeSubType = 'all';
+        searchOfferedCubeStore.set(false);
         matchIDsInput = '';
         tournamentIDsInput = '';
         creationDateOption = 'min';
@@ -1043,6 +1146,7 @@
             player2JanBlotRangeMin,
             player2JanBlotRangeMax,
             diceRollOption,
+            cubeSubType,
             creationDateOption,
             creationDateMin,
             creationDateMax,
@@ -1180,6 +1284,7 @@
         player2JanBlotRangeMin = saved.player2JanBlotRangeMin;
         player2JanBlotRangeMax = saved.player2JanBlotRangeMax;
         if (saved.diceRollOption) diceRollOption = saved.diceRollOption;
+        if (saved.cubeSubType) cubeSubType = saved.cubeSubType;
         creationDateOption = saved.creationDateOption;
         creationDateMin = saved.creationDateMin;
         creationDateMax = saved.creationDateMax;
@@ -1197,6 +1302,8 @@
 
     onDestroy(() => {
         saveSearchState();
+        // Don't leak the offered-cube flag into normal position editing.
+        searchOfferedCubeStore.set(false);
         document.removeEventListener('keydown', handleKeyDown);
     });
 </script>
@@ -1239,12 +1346,57 @@
                             {#each group.filters as filter (filter)}
                                 <div class="filter-item" class:active={filterEnabled[filter]}>
                                     <label class="filter-checkbox">
-                                        <input type="checkbox" bind:checked={filterEnabled[filter]} />
-                                        <span class="filter-label">{filterLabel(filter)}</span>
+                                        <input
+                                            type="checkbox"
+                                            bind:checked={filterEnabled[filter]}
+                                            disabled={filter === 'Include Dice Roll' && filterEnabled['Include Decision Type'] && decisionMode === 'cube'}
+                                        />
+                                        <span class="filter-label" class:label-disabled={filter === 'Include Dice Roll' && filterEnabled['Include Decision Type'] && decisionMode === 'cube'}
+                                            >{filterLabel(filter)}</span
+                                        >
                                     </label>
                                     {#if filterEnabled[filter]}
                                         <div class="filter-params">
-                                            {#if filter === 'Include Dice Roll'}
+                                            {#if filter === 'Include Decision Type'}
+                                                <div class="decision-mode-controls">
+                                                    <div class="decision-segment">
+                                                        <button type="button" class="decision-btn" class:active={decisionMode === 'checker'} onclick={() => selectDecisionMode('checker')}
+                                                            >{$t('search.decision.checker')}</button
+                                                        >
+                                                        <button type="button" class="decision-btn" class:active={decisionMode === 'cube'} onclick={() => selectDecisionMode('cube')}
+                                                            >{$t('search.decision.cube')}</button
+                                                        >
+                                                    </div>
+                                                    {#if decisionMode === 'cube'}
+                                                        <div class="minmax-controls">
+                                                            <label
+                                                                ><input type="radio" name="cubeSubType" value="all" checked={cubeSubType === 'all'} onchange={() => selectCubeSubType('all')} />
+                                                                {$t('search.decision.cubeAll')}</label
+                                                            >
+                                                            <label
+                                                                ><input
+                                                                    type="radio"
+                                                                    name="cubeSubType"
+                                                                    value="double"
+                                                                    checked={cubeSubType === 'double'}
+                                                                    onchange={() => selectCubeSubType('double')}
+                                                                />
+                                                                {$t('search.decision.cubeDouble')}</label
+                                                            >
+                                                            <label
+                                                                ><input
+                                                                    type="radio"
+                                                                    name="cubeSubType"
+                                                                    value="takepass"
+                                                                    checked={cubeSubType === 'takepass'}
+                                                                    onchange={() => selectCubeSubType('takepass')}
+                                                                />
+                                                                {$t('search.decision.cubeTakePass')}</label
+                                                            >
+                                                        </div>
+                                                    {/if}
+                                                </div>
+                                            {:else if filter === 'Include Dice Roll'}
                                                 <div class="minmax-controls">
                                                     <label><input type="radio" bind:group={diceRollOption} value="both" /> {$t('search.bothDice')}</label>
                                                     <label><input type="radio" bind:group={diceRollOption} value="first" /> {$t('search.firstDieOnly')}</label>
@@ -2253,6 +2405,36 @@
     }
     .btn-clear:hover {
         background: #999;
+    }
+    .decision-mode-controls {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+    }
+    .decision-segment {
+        display: flex;
+        gap: 4px;
+    }
+    .decision-btn {
+        font-size: 11px;
+        padding: 3px 10px;
+        border: 1px solid #ccc;
+        background: #fff;
+        color: #555;
+        border-radius: 3px;
+        cursor: pointer;
+    }
+    .decision-btn:hover {
+        background: #f0f0f0;
+    }
+    .decision-btn.active {
+        color: #333;
+        font-weight: 600;
+        border-color: #555;
+        background: #fff;
+    }
+    .label-disabled {
+        opacity: 0.45;
     }
     .minmax-controls {
         display: flex;

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -224,6 +224,13 @@
         "searchTextHint": "Suchtext",
         "selectFilter": "Filter auswählen",
         "tournamentIdsHint": "Turnier-IDs",
+        "decision": {
+            "checker": "Zug",
+            "cube": "Dopplung",
+            "cubeAll": "Alle",
+            "cubeDouble": "Dopplung / Kein Doppel",
+            "cubeTakePass": "Annehmen / Aufgeben"
+        },
         "filters": {
             "includeCube": "Dopplerwürfel einbeziehen",
             "includeScore": "Spielstand einbeziehen",

--- a/frontend/src/i18n/locales/el.json
+++ b/frontend/src/i18n/locales/el.json
@@ -224,6 +224,13 @@
         "searchTextHint": "Κείμενο αναζήτησης",
         "selectFilter": "Επιλέξτε ένα φίλτρο",
         "tournamentIdsHint": "ID τουρνουά",
+        "decision": {
+            "checker": "Πιόνια",
+            "cube": "Κύβος",
+            "cubeAll": "Όλα",
+            "cubeDouble": "Διπλασιασμός / Όχι",
+            "cubeTakePass": "Αποδοχή / Πάσο"
+        },
         "filters": {
             "includeCube": "Συμπερίληψη κύβου",
             "includeScore": "Συμπερίληψη σκορ",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -224,10 +224,17 @@
         "searchTextHint": "Search text",
         "selectFilter": "Select a filter",
         "tournamentIdsHint": "Tournament IDs",
+        "decision": {
+            "checker": "Checker",
+            "cube": "Cube",
+            "cubeAll": "All",
+            "cubeDouble": "Double / No double",
+            "cubeTakePass": "Take / Pass"
+        },
         "filters": {
             "includeCube": "Include Cube",
             "includeScore": "Include Score",
-            "includeDecisionType": "Include Decision Type",
+            "includeDecisionType": "Decision Type",
             "includeDiceRoll": "Include Dice Roll",
             "noContact": "No Contact",
             "mirrorPosition": "Mirror Position",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -224,6 +224,13 @@
         "searchTextHint": "Texto de búsqueda",
         "selectFilter": "Selecciona un filtro",
         "tournamentIdsHint": "ID de torneos",
+        "decision": {
+            "checker": "Fichas",
+            "cube": "Cubo",
+            "cubeAll": "Todos",
+            "cubeDouble": "Doblar / No doblar",
+            "cubeTakePass": "Aceptar / Pasar"
+        },
         "filters": {
             "includeCube": "Incluir cubo",
             "includeScore": "Incluir marcador",

--- a/frontend/src/i18n/locales/fi.json
+++ b/frontend/src/i18n/locales/fi.json
@@ -224,6 +224,13 @@
         "searchTextHint": "Hakuteksti",
         "selectFilter": "Valitse suodatin",
         "tournamentIdsHint": "Turnaustunnukset",
+        "decision": {
+            "checker": "Siirto",
+            "cube": "Tuplaus",
+            "cubeAll": "Kaikki",
+            "cubeDouble": "Tuplaus / Ei tuplausta",
+            "cubeTakePass": "Hyväksy / Luovuta"
+        },
         "filters": {
             "includeCube": "Sisällytä tuplauskuutio",
             "includeScore": "Sisällytä pistetilanne",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -224,10 +224,17 @@
         "searchTextHint": "Texte de recherche",
         "selectFilter": "Sélectionner un filtre",
         "tournamentIdsHint": "ID de tournoi",
+        "decision": {
+            "checker": "Pions",
+            "cube": "Videau",
+            "cubeAll": "Tous",
+            "cubeDouble": "Double / Pas de double",
+            "cubeTakePass": "Prise / Passe"
+        },
         "filters": {
             "includeCube": "Inclure le videau",
             "includeScore": "Inclure le score",
-            "includeDecisionType": "Inclure le type de décision",
+            "includeDecisionType": "Type de décision",
             "includeDiceRoll": "Inclure le lancer de dés",
             "noContact": "Sans contact",
             "mirrorPosition": "Position miroir",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -224,6 +224,13 @@
         "searchTextHint": "Testo da cercare",
         "selectFilter": "Seleziona un filtro",
         "tournamentIdsHint": "ID dei tornei",
+        "decision": {
+            "checker": "Pedine",
+            "cube": "Cubo",
+            "cubeAll": "Tutti",
+            "cubeDouble": "Raddoppio / No raddoppio",
+            "cubeTakePass": "Accetta / Passa"
+        },
         "filters": {
             "includeCube": "Includi cubo",
             "includeScore": "Includi punteggio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -224,6 +224,13 @@
         "searchTextHint": "検索テキスト",
         "selectFilter": "フィルターを選択",
         "tournamentIdsHint": "トーナメント ID",
+        "decision": {
+            "checker": "チェッカー",
+            "cube": "キューブ",
+            "cubeAll": "すべて",
+            "cubeDouble": "ダブル / ノーダブル",
+            "cubeTakePass": "テイク / パス"
+        },
         "filters": {
             "includeCube": "キューブを含める",
             "includeScore": "スコアを含める",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -224,6 +224,13 @@
         "searchTextHint": "Текст поиска",
         "selectFilter": "Выберите фильтр",
         "tournamentIdsHint": "ID турниров",
+        "decision": {
+            "checker": "Шашки",
+            "cube": "Куб",
+            "cubeAll": "Все",
+            "cubeDouble": "Дабл / Без дабла",
+            "cubeTakePass": "Тейк / Пас"
+        },
         "filters": {
             "includeCube": "Включить куб",
             "includeScore": "Включить счёт",

--- a/frontend/src/services/positionService.js
+++ b/frontend/src/services/positionService.js
@@ -401,6 +401,11 @@ export async function loadPositionsByFilters(
 
         const searchFilterPositionJSON = JSON.stringify(currentPosition);
 
+        // Cube sub-type (only meaningful when the decision-type filter is a cube
+        // decision): `dr` = take/pass responses, `dd` = double/no-double. Derived
+        // from the filter tokens so both the panel and the command line share it.
+        const cubeResponseFilter = Array.isArray(filters) ? (filters.includes('dr') ? 'takepass' : filters.includes('dd') ? 'double' : '') : '';
+
         const loadedPositions = await LoadPositionsByFilters({
             filter: currentPosition,
             excludeFilter: excludePosition,
@@ -423,6 +428,7 @@ export async function loadPositionsByFilters(
             player1AbsolutePipCountFilter,
             equityFilter,
             decisionTypeFilter,
+            cubeResponseFilter,
             diceRollFilter,
             diceRollMode,
             movePatternFilter,

--- a/frontend/src/stores/searchExcludePositionStore.js
+++ b/frontend/src/stores/searchExcludePositionStore.js
@@ -27,6 +27,11 @@ export const searchExcludePositionStore = writable(emptySearchBoardPosition());
 // Read by the board container to show a red cue while editing the exclude structure.
 export const searchStructureModeStore = writable('include');
 
+// True while the Search panel is building a take/pass (cube response) query: the
+// board then renders and edits the cube as a centered "offered" cube (owner -1)
+// instead of an owned one, matching how take/pass positions are stored.
+export const searchOfferedCubeStore = writable(false);
+
 // boardHasCheckers reports whether a position/board template has any checker set.
 export function boardHasCheckers(position) {
     const points = position?.board?.points;

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1108,6 +1108,7 @@ export namespace domain {
 	    player1AbsolutePipCountFilter: string;
 	    equityFilter: string;
 	    decisionTypeFilter: boolean;
+	    cubeResponseFilter: string;
 	    diceRollFilter: boolean;
 	    diceRollMode: string;
 	    movePatternFilter: string;
@@ -1151,6 +1152,7 @@ export namespace domain {
 	        this.player1AbsolutePipCountFilter = source["player1AbsolutePipCountFilter"];
 	        this.equityFilter = source["equityFilter"];
 	        this.decisionTypeFilter = source["decisionTypeFilter"];
+	        this.cubeResponseFilter = source["cubeResponseFilter"];
 	        this.diceRollFilter = source["diceRollFilter"];
 	        this.diceRollMode = source["diceRollMode"];
 	        this.movePatternFilter = source["movePatternFilter"];

--- a/pkg/blunderdb/database/db.go
+++ b/pkg/blunderdb/database/db.go
@@ -151,7 +151,8 @@ func (d *Database) SetupDatabase(path string) error {
             occupancy_2       INTEGER,
             point_mask_1      INTEGER,
             point_mask_2      INTEGER,
-            state             TEXT    NOT NULL
+            state             TEXT    NOT NULL,
+            is_cube_response  INTEGER NOT NULL DEFAULT 0
         )
     `)
 	if err != nil {
@@ -460,6 +461,7 @@ func (d *Database) SetupDatabase(path string) error {
 		`CREATE UNIQUE INDEX IF NOT EXISTS idx_position_zobrist        ON position(zobrist_hash)`,
 		`CREATE        INDEX IF NOT EXISTS idx_position_decision_pip   ON position(decision_type, pip_diff)`,
 		`CREATE        INDEX IF NOT EXISTS idx_position_decision_dice  ON position(decision_type, dice_1, dice_2)`,
+		`CREATE        INDEX IF NOT EXISTS idx_position_cube_response  ON position(decision_type, is_cube_response)`,
 		`CREATE        INDEX IF NOT EXISTS idx_position_pip_diff       ON position(pip_diff)`,
 		`CREATE        INDEX IF NOT EXISTS idx_position_dice           ON position(dice_1, dice_2)`,
 		`CREATE        INDEX IF NOT EXISTS idx_position_off            ON position(off_1, off_2)`,

--- a/pkg/blunderdb/database/db_import_common.go
+++ b/pkg/blunderdb/database/db_import_common.go
@@ -453,6 +453,20 @@ func (d *Database) saveAnalysisInTx(tx *sql.Tx, positionID int64, analysis Posit
 		}
 	}
 
+	// Flag the position as a take/pass cube response if any recorded played cube
+	// action is a response (Take/Pass/Drop) rather than a doubling decision. This
+	// lets search distinguish "double/no-double" from "take/pass" cube decisions.
+	// OR semantics across matches for a deduped position: only ever set to 1,
+	// never reset to 0.
+	for _, action := range analysis.PlayedCubeActions {
+		if engine.IsResponseCubeAction(action) {
+			if _, err := tx.Exec(`UPDATE position SET is_cube_response = 1 WHERE id = ?`, positionID); err != nil {
+				return err
+			}
+			break
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/blunderdb/database/db_migration.go
+++ b/pkg/blunderdb/database/db_migration.go
@@ -1071,6 +1071,127 @@ func (d *Database) migrate_2_5_0_to_2_6_0(ctx context.Context) error {
 	return nil
 }
 
+// migrate_2_9_0_to_2_10_0 adds the is_cube_response column to position and
+// backfills it: a cube position (decision_type = 1) is flagged 1 when any of its
+// recorded played cube actions is a take/pass response (engine.IsResponseCubeAction),
+// as opposed to a doubling decision (Double / No Double / Redouble). This lets the
+// search filter distinguish "double/no-double" from "take/pass" cube decisions.
+func (d *Database) migrate_2_9_0_to_2_10_0(ctx context.Context) error {
+	if _, err := d.db.Exec(`ALTER TABLE position ADD COLUMN is_cube_response INTEGER NOT NULL DEFAULT 0`); err != nil {
+		if err.Error() != `duplicate column name: is_cube_response` {
+			return fmt.Errorf("migrate 2.10.0 add column: %w", err)
+		}
+	}
+
+	if _, err := d.db.Exec(`CREATE INDEX IF NOT EXISTS idx_position_cube_response ON position(decision_type, is_cube_response)`); err != nil {
+		// On minimal legacy schemas decision_type may not exist yet; the v2
+		// column backfill (ensureAllTablesExist) re-creates this index afterwards.
+		slog.Debug("migrate 2.10.0 deferring cube_response index", "err", err)
+	}
+
+	// Backfill all cube positions (decision_type = 1) from the move table.
+	var total int
+	_ = d.db.QueryRow(`SELECT COUNT(*) FROM position WHERE decision_type = 1`).Scan(&total)
+
+	if total > 0 {
+		updateStmt, err := d.db.Prepare(`UPDATE position SET is_cube_response = 1 WHERE id = ?`)
+		if err != nil {
+			return fmt.Errorf("migrate 2.10.0 prepare update: %w", err)
+		}
+		defer updateStmt.Close()
+
+		// Look up the played cube actions for a position from the move table.
+		lookupActions, err := d.db.Prepare(`
+			SELECT COALESCE(cube_action, '')
+			FROM move
+			WHERE position_id = ? AND cube_action IS NOT NULL AND cube_action != ''`)
+		if err != nil {
+			return fmt.Errorf("migrate 2.10.0 prepare action lookup: %w", err)
+		}
+		defer lookupActions.Close()
+
+		tx, err := d.db.Begin()
+		if err != nil {
+			return fmt.Errorf("migrate 2.10.0 begin tx: %w", err)
+		}
+
+		const batchSize = 1000
+		var lastID int64
+		done := 0
+
+		for {
+			if err := ctx.Err(); err != nil {
+				tx.Rollback()
+				return err
+			}
+
+			rows, err := d.db.Query(`
+				SELECT id FROM position
+				WHERE decision_type = 1 AND id > ?
+				ORDER BY id LIMIT ?`, lastID, batchSize)
+			if err != nil {
+				tx.Rollback()
+				return fmt.Errorf("migrate 2.10.0 query: %w", err)
+			}
+			var batch []int64
+			for rows.Next() {
+				var id int64
+				if err := rows.Scan(&id); err == nil {
+					batch = append(batch, id)
+				}
+			}
+			rows.Close()
+
+			if len(batch) == 0 {
+				break
+			}
+
+			for _, id := range batch {
+				lastID = id
+
+				// A position is a response if ANY of its played cube actions is a
+				// take/pass (OR semantics across matches for a deduped position).
+				isResp := false
+				actRows, err := lookupActions.Query(id)
+				if err == nil {
+					for actRows.Next() {
+						var ca string
+						if err := actRows.Scan(&ca); err == nil && engine.IsResponseCubeAction(ca) {
+							isResp = true
+						}
+					}
+					actRows.Close()
+				}
+
+				if isResp {
+					if _, err := tx.Stmt(updateStmt).Exec(id); err != nil {
+						tx.Rollback()
+						return fmt.Errorf("migrate 2.10.0 update: %w", err)
+					}
+				}
+				done++
+				if done%500 == 0 {
+					d.emitMigrationProgress("is_cube_response_backfill", done, total)
+				}
+			}
+		}
+
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("migrate 2.10.0 commit: %w", err)
+		}
+		d.emitMigrationProgress("is_cube_response_backfill", total, total)
+	}
+
+	_, _ = d.db.Exec(`ANALYZE`)
+
+	if _, err := d.db.Exec(`UPDATE metadata SET value='2.10.0' WHERE key='database_version'`); err != nil {
+		return fmt.Errorf("migrate version bump: %w", err)
+	}
+
+	slog.Info("database upgraded", "from", "2.9.0", "to", "2.10.0")
+	return nil
+}
+
 // migrate_2_6_0_to_2_7_0 fixes Zobrist hashes that were computed with the wrong
 // cube-value convention. The ZobristHash function received Cube.Value as an EXPONENT
 // (0=cube@1, 1=cube@2, 2=cube@4, …) but passed it to cubeValueIndex() which expects
@@ -1700,6 +1821,16 @@ func (d *Database) runMigrationChain(ctx context.Context) error {
 			return fmt.Errorf("migration 2.8.0→2.9.0 failed: %w", err)
 		}
 		dbVersion = "2.9.0"
+	}
+
+	// Auto-migrate from 2.9.0 to 2.10.0
+	// Adds is_cube_response column to position; backfills cube positions by
+	// detecting take/pass responses from the move table (engine.IsResponseCubeAction).
+	if dbVersion == "2.9.0" {
+		if err := d.migrate_2_9_0_to_2_10_0(ctx); err != nil {
+			return fmt.Errorf("migration 2.9.0→2.10.0 failed: %w", err)
+		}
+		dbVersion = "2.10.0"
 	}
 
 	// Ensure all required tables and columns exist.

--- a/pkg/blunderdb/database/db_schema.go
+++ b/pkg/blunderdb/database/db_schema.go
@@ -292,6 +292,7 @@ func (d *Database) ensureAllTablesExist() error {
 		`ALTER TABLE position ADD COLUMN occupancy_2    INTEGER`,
 		`ALTER TABLE position ADD COLUMN point_mask_1   INTEGER`,
 		`ALTER TABLE position ADD COLUMN point_mask_2   INTEGER`,
+		`ALTER TABLE position ADD COLUMN is_cube_response INTEGER NOT NULL DEFAULT 0`,
 	}
 	for _, stmt := range newPositionCols {
 		_, _ = d.db.Exec(stmt) // ignore error: column may already exist
@@ -316,6 +317,7 @@ func (d *Database) ensureAllTablesExist() error {
 	v2indexesSafe := []string{
 		`CREATE INDEX IF NOT EXISTS idx_position_decision_pip   ON position(decision_type, pip_diff)`,
 		`CREATE INDEX IF NOT EXISTS idx_position_decision_dice  ON position(decision_type, dice_1, dice_2)`,
+		`CREATE INDEX IF NOT EXISTS idx_position_cube_response  ON position(decision_type, is_cube_response)`,
 		`CREATE INDEX IF NOT EXISTS idx_position_pip_diff       ON position(pip_diff)`,
 		`CREATE INDEX IF NOT EXISTS idx_position_dice           ON position(dice_1, dice_2)`,
 		`CREATE INDEX IF NOT EXISTS idx_position_off            ON position(off_1, off_2)`,

--- a/pkg/blunderdb/database/gnubg_import_test.go
+++ b/pkg/blunderdb/database/gnubg_import_test.go
@@ -7,8 +7,66 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kevung/blunderdb/pkg/blunderdb/engine"
 	_ "modernc.org/sqlite"
 )
+
+// TestImport_PopulatesIsCubeResponse verifies that importing a real match sets
+// position.is_cube_response exactly for the cube positions whose played cube
+// action is a take/pass response (engine.IsResponseCubeAction).
+func TestImport_PopulatesIsCubeResponse(t *testing.T) {
+	db := newTestDB(t)
+
+	testFile := filepath.Join("testdata", "test.sgf")
+	if _, err := os.Stat(testFile); os.IsNotExist(err) {
+		t.Skip("test.sgf not found in testdata/")
+	}
+	if _, err := db.ImportGnuBGMatch(testFile); err != nil {
+		t.Fatalf("ImportGnuBGMatch: %v", err)
+	}
+
+	rows, err := db.db.Query(`
+		SELECT p.id, p.is_cube_response, COALESCE(m.cube_action, '')
+		FROM position p
+		LEFT JOIN move m ON m.position_id = p.id
+		WHERE p.decision_type = 1`)
+	if err != nil {
+		t.Fatalf("query cube positions: %v", err)
+	}
+	defer rows.Close()
+
+	stored := map[int64]bool{}   // position id → stored is_cube_response flag
+	expected := map[int64]bool{} // position id → any take/pass action seen
+	for rows.Next() {
+		var id int64
+		var flag int
+		var action string
+		if err := rows.Scan(&id, &flag, &action); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		stored[id] = flag == 1
+		if engine.IsResponseCubeAction(action) {
+			expected[id] = true
+		}
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	if len(stored) == 0 {
+		t.Skip("no cube positions in test.sgf")
+	}
+	responses := 0
+	for id := range stored {
+		if stored[id] != expected[id] {
+			t.Errorf("position %d: is_cube_response=%v, want %v", id, stored[id], expected[id])
+		}
+		if expected[id] {
+			responses++
+		}
+	}
+	t.Logf("cube positions=%d, take/pass responses=%d", len(stored), responses)
+}
 
 // testUnmarshalPositionState unmarshals a position state string that may be
 // either compact board encoding ([28]int array) or legacy full-JSON.

--- a/pkg/blunderdb/database/migration_test.go
+++ b/pkg/blunderdb/database/migration_test.go
@@ -1631,3 +1631,117 @@ func TestMigrate_2_5_0_to_2_6_0_IsCloseCube(t *testing.T) {
 		}
 	}
 }
+
+// TestMigrate_2_9_0_to_2_10_0_IsCubeResponse verifies the is_cube_response column
+// is added and backfilled from the move table: cube positions whose played cube
+// action is a take/pass response get 1, doubling decisions and checker positions
+// stay 0.
+func TestMigrate_2_9_0_to_2_10_0_IsCubeResponse(t *testing.T) {
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "v290_is_cube_response.db")
+
+	rawDB, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+
+	_, err = rawDB.Exec(`
+		CREATE TABLE position (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			state TEXT,
+			decision_type INTEGER DEFAULT 0
+		);
+		CREATE TABLE analysis (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			position_id INTEGER,
+			data BLOB
+		);
+		CREATE TABLE comment (id INTEGER PRIMARY KEY, position_id INTEGER, text TEXT);
+		CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT);
+		CREATE TABLE command_history (id INTEGER PRIMARY KEY AUTOINCREMENT, command TEXT, timestamp DATETIME DEFAULT CURRENT_TIMESTAMP);
+		CREATE TABLE filter_library (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, command TEXT, edit_position TEXT);
+		CREATE TABLE search_history (id INTEGER PRIMARY KEY AUTOINCREMENT, command TEXT, position TEXT, timestamp INTEGER);
+		CREATE TABLE match (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			player1_name TEXT, player2_name TEXT,
+			match_length INTEGER, match_date DATETIME,
+			import_date DATETIME DEFAULT CURRENT_TIMESTAMP,
+			file_path TEXT, game_count INTEGER DEFAULT 0,
+			match_hash TEXT, tournament_id INTEGER,
+			last_visited_position INTEGER DEFAULT -1
+		);
+		CREATE TABLE game (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			match_id INTEGER, game_number INTEGER,
+			initial_score_1 INTEGER, initial_score_2 INTEGER,
+			winner INTEGER, points_won INTEGER,
+			move_count INTEGER DEFAULT 0
+		);
+		CREATE TABLE move (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			game_id INTEGER, move_number INTEGER,
+			move_type TEXT, position_id INTEGER,
+			player INTEGER, dice_1 INTEGER, dice_2 INTEGER,
+			checker_move TEXT, cube_action TEXT
+		);
+		CREATE TABLE move_analysis (id INTEGER PRIMARY KEY AUTOINCREMENT, move_id INTEGER, analysis_type TEXT);
+		CREATE TABLE collection (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, description TEXT, sort_order INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP);
+		CREATE TABLE collection_position (id INTEGER PRIMARY KEY AUTOINCREMENT, collection_id INTEGER NOT NULL, position_id INTEGER NOT NULL, sort_order INTEGER DEFAULT 0, added_at DATETIME DEFAULT CURRENT_TIMESTAMP, UNIQUE(collection_id, position_id));
+		CREATE TABLE tournament (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, date TEXT, location TEXT, sort_order INTEGER DEFAULT 0, created_at DATETIME DEFAULT CURRENT_TIMESTAMP, updated_at DATETIME DEFAULT CURRENT_TIMESTAMP);
+		INSERT INTO metadata (key, value) VALUES ('database_version', '2.9.0');
+	`)
+	if err != nil {
+		t.Fatalf("setup schema: %v", err)
+	}
+
+	// id=1: cube, Take response → 1
+	// id=2: cube, Double (doubling decision) → 0
+	// id=3: cube, No Double → 0
+	// id=4: cube, Pass response → 1
+	// id=5: checker position → 0
+	rawDB.Exec(`INSERT INTO position (id, state, decision_type) VALUES (1,'{}',1)`)
+	rawDB.Exec(`INSERT INTO position (id, state, decision_type) VALUES (2,'{}',1)`)
+	rawDB.Exec(`INSERT INTO position (id, state, decision_type) VALUES (3,'{}',1)`)
+	rawDB.Exec(`INSERT INTO position (id, state, decision_type) VALUES (4,'{}',1)`)
+	rawDB.Exec(`INSERT INTO position (id, state, decision_type) VALUES (5,'{}',0)`)
+	rawDB.Exec(`INSERT INTO move (game_id, move_number, move_type, position_id, cube_action) VALUES (1,1,'cube',1,'Take')`)
+	rawDB.Exec(`INSERT INTO move (game_id, move_number, move_type, position_id, cube_action) VALUES (1,2,'cube',2,'Double')`)
+	rawDB.Exec(`INSERT INTO move (game_id, move_number, move_type, position_id, cube_action) VALUES (1,3,'cube',3,'No Double')`)
+	rawDB.Exec(`INSERT INTO move (game_id, move_number, move_type, position_id, cube_action) VALUES (1,4,'cube',4,'Pass')`)
+	rawDB.Close()
+
+	d := NewDatabase()
+	if err := d.OpenDatabase(dbPath); err != nil {
+		t.Fatalf("OpenDatabase: %v", err)
+	}
+
+	ver, _ := d.CheckDatabaseVersion()
+	if ver != DatabaseVersion {
+		t.Errorf("expected version %s, got %s", DatabaseVersion, ver)
+	}
+
+	var colExists int
+	d.db.QueryRow(`SELECT COUNT(*) FROM pragma_table_info('position') WHERE name='is_cube_response'`).Scan(&colExists)
+	if colExists != 1 {
+		t.Fatalf("is_cube_response column not found after migration")
+	}
+
+	cases := []struct {
+		id       int
+		wantResp int
+		label    string
+	}{
+		{1, 1, "Take response"},
+		{2, 0, "Double decision"},
+		{3, 0, "No Double decision"},
+		{4, 1, "Pass response"},
+		{5, 0, "checker position"},
+	}
+	for _, tc := range cases {
+		var got int
+		d.db.QueryRow(`SELECT is_cube_response FROM position WHERE id = ?`, tc.id).Scan(&got)
+		if got != tc.wantResp {
+			t.Errorf("position id=%d (%s): is_cube_response=%d, want %d", tc.id, tc.label, got, tc.wantResp)
+		}
+	}
+}

--- a/pkg/blunderdb/domain/domain.go
+++ b/pkg/blunderdb/domain/domain.go
@@ -39,7 +39,7 @@ const (
 )
 
 const (
-	DatabaseVersion = "2.9.0"
+	DatabaseVersion = "2.10.0"
 )
 
 // Anki deck source types
@@ -171,6 +171,7 @@ type SearchFilters struct {
 	Player1AbsolutePipCountFilter string   `json:"player1AbsolutePipCountFilter"`
 	EquityFilter                  string   `json:"equityFilter"`
 	DecisionTypeFilter            bool     `json:"decisionTypeFilter"`
+	CubeResponseFilter            string   `json:"cubeResponseFilter"` // "" = all cube decisions, "double" = double/no-double only, "takepass" = take/pass only
 	DiceRollFilter                bool     `json:"diceRollFilter"`
 	DiceRollMode                  string   `json:"diceRollMode"`
 	MovePatternFilter             string   `json:"movePatternFilter"`

--- a/pkg/blunderdb/storage/postgres/analyses_postgres.go
+++ b/pkg/blunderdb/storage/postgres/analyses_postgres.go
@@ -72,6 +72,19 @@ func (s *analysisStore) Save(ctx context.Context, scope string, positionID int64
 	if err != nil {
 		return fmt.Errorf("postgres: save analysis: %w", err)
 	}
+
+	// Flag the position as a take/pass cube response if any played cube action is
+	// a response (only ever set to TRUE; OR semantics for a deduped position).
+	for _, action := range a.PlayedCubeActions {
+		if engine.IsResponseCubeAction(action) {
+			if _, err := s.db.Exec(ctx,
+				`UPDATE position SET is_cube_response = TRUE WHERE id = $1 AND tenant_id = $2`,
+				positionID, tenant); err != nil {
+				return fmt.Errorf("postgres: flag cube response: %w", err)
+			}
+			break
+		}
+	}
 	return nil
 }
 

--- a/pkg/blunderdb/storage/postgres/migrate_postgres.go
+++ b/pkg/blunderdb/storage/postgres/migrate_postgres.go
@@ -1,0 +1,79 @@
+package postgres
+
+import (
+	"context"
+	"embed"
+	"fmt"
+	"io/fs"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// migrationsFS holds the forward migration files. 001 is the bootstrap baseline
+// applied by bootstrap() on a fresh database; 002+ are forward migrations applied
+// by migrateForward() to bring an existing database up to the current schema.
+//
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// migrateForward applies every forward migration (002+) that has not yet been
+// recorded in schema_migrations, in numeric order. Each migration is idempotent
+// (ADD COLUMN IF NOT EXISTS, CREATE INDEX IF NOT EXISTS, …), so applying one to a
+// freshly bootstrapped database — whose baseline already contains the change — is
+// harmless; it is simply recorded as applied so it is not replayed on later opens.
+//
+// The v2.7.0 baseline (001) is never replayed here.
+func migrateForward(ctx context.Context, pool *pgxpool.Pool) error {
+	if _, err := pool.Exec(ctx,
+		`CREATE TABLE IF NOT EXISTS schema_migrations (
+			version    TEXT PRIMARY KEY,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+		)`); err != nil {
+		return fmt.Errorf("postgres: ensure schema_migrations: %w", err)
+	}
+
+	entries, err := fs.ReadDir(migrationsFS, "migrations")
+	if err != nil {
+		return fmt.Errorf("postgres: read migrations dir: %w", err)
+	}
+
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasSuffix(name, ".sql") || strings.HasPrefix(name, "001_") {
+			continue // skip the bootstrap baseline and non-SQL files
+		}
+		files = append(files, name)
+	}
+	sort.Strings(files)
+
+	for _, name := range files {
+		version := strings.TrimSuffix(name, ".sql")
+
+		var applied bool
+		if err := pool.QueryRow(ctx,
+			`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)`, version).Scan(&applied); err != nil {
+			return fmt.Errorf("postgres: check migration %s: %w", version, err)
+		}
+		if applied {
+			continue
+		}
+
+		stmt, err := migrationsFS.ReadFile("migrations/" + name)
+		if err != nil {
+			return fmt.Errorf("postgres: read migration %s: %w", name, err)
+		}
+		// Run as one batch via the simple query protocol (Exec with no bound
+		// arguments), which permits the multiple semicolon-separated statements.
+		if _, err := pool.Exec(ctx, string(stmt)); err != nil {
+			return fmt.Errorf("postgres: apply migration %s: %w", version, err)
+		}
+		if _, err := pool.Exec(ctx,
+			`INSERT INTO schema_migrations (version) VALUES ($1) ON CONFLICT DO NOTHING`, version); err != nil {
+			return fmt.Errorf("postgres: record migration %s: %w", version, err)
+		}
+	}
+	return nil
+}

--- a/pkg/blunderdb/storage/postgres/migrations/001_initial_v2_7_0.sql
+++ b/pkg/blunderdb/storage/postgres/migrations/001_initial_v2_7_0.sql
@@ -40,7 +40,8 @@ CREATE TABLE IF NOT EXISTS position (
     occupancy_2       BIGINT,
     point_mask_1      BIGINT,
     point_mask_2      BIGINT,
-    state             TEXT    NOT NULL
+    state             TEXT    NOT NULL,
+    is_cube_response  BOOLEAN NOT NULL DEFAULT FALSE
 );
 
 CREATE TABLE IF NOT EXISTS analysis (
@@ -231,6 +232,7 @@ CREATE TABLE IF NOT EXISTS anki_card (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_position_zobrist        ON position (tenant_id, zobrist_hash);
 CREATE        INDEX IF NOT EXISTS idx_position_decision_pip   ON position (tenant_id, decision_type, pip_diff);
 CREATE        INDEX IF NOT EXISTS idx_position_decision_dice  ON position (tenant_id, decision_type, dice_1, dice_2);
+CREATE        INDEX IF NOT EXISTS idx_position_cube_response  ON position (tenant_id, decision_type) WHERE is_cube_response;
 CREATE        INDEX IF NOT EXISTS idx_position_pip_diff       ON position (tenant_id, pip_diff);
 CREATE        INDEX IF NOT EXISTS idx_position_dice           ON position (tenant_id, dice_1, dice_2);
 CREATE        INDEX IF NOT EXISTS idx_position_off            ON position (tenant_id, off_1, off_2);

--- a/pkg/blunderdb/storage/postgres/migrations/002_is_cube_response.sql
+++ b/pkg/blunderdb/storage/postgres/migrations/002_is_cube_response.sql
@@ -1,0 +1,31 @@
+-- Forward migration: add the is_cube_response column to position and backfill
+-- take/pass responses from the move table. Idempotent, so it is safe on a fresh
+-- database (whose v2.7.0 baseline already includes the column) and on existing
+-- databases bootstrapped before this column existed.
+--
+-- The response predicate mirrors engine.IsResponseCubeAction: an action is a
+-- take/pass response when, after lower-casing and removing spaces, it does NOT
+-- contain "double" and is "dt"/"dp" or contains take/pass/drop.
+
+ALTER TABLE position ADD COLUMN IF NOT EXISTS is_cube_response BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_position_cube_response ON position (tenant_id, decision_type) WHERE is_cube_response;
+
+UPDATE position p
+SET is_cube_response = TRUE
+FROM (
+    SELECT DISTINCT position_id
+    FROM move
+    WHERE cube_action IS NOT NULL
+      AND lower(replace(cube_action, ' ', '')) NOT LIKE '%double%'
+      AND (
+            lower(replace(cube_action, ' ', '')) IN ('dt', 'dp')
+         OR lower(replace(cube_action, ' ', '')) LIKE '%take%'
+         OR lower(replace(cube_action, ' ', '')) LIKE '%pass%'
+         OR lower(replace(cube_action, ' ', '')) LIKE '%drop%'
+      )
+) resp
+WHERE resp.position_id = p.id
+  AND p.decision_type = 1;
+
+UPDATE metadata SET value = '2.10.0' WHERE key = 'database_version';

--- a/pkg/blunderdb/storage/postgres/migrations/README.md
+++ b/pkg/blunderdb/storage/postgres/migrations/README.md
@@ -18,11 +18,22 @@ So PostgreSQL **starts fresh at the terminal SQLite schema, v2.7.0**:
 ## Forward chain
 
 New schema changes are added as `NNN_description.sql` files, applied in
-numeric order. `002_*.sql` is reserved for P4 (the `scope` column on
-`session` / per-session tables).
+numeric order by `migrateForward` (see `migrate_postgres.go`). On every `Open`
+/ `Migrate`, each file beyond the `001` baseline that is not yet recorded in the
+`schema_migrations` table is applied (simple-protocol batch) and recorded. Make
+every migration **idempotent** (`ADD COLUMN IF NOT EXISTS`,
+`CREATE INDEX IF NOT EXISTS`, set-based backfills) so that applying it to a
+freshly bootstrapped database — whose `001` baseline already contains the change
+— is a harmless no-op.
 
-When you add a migration, also bump `domain.DatabaseVersion` if the change is
-schema-visible, and extend the migration test.
+- `002_is_cube_response.sql` — `position.is_cube_response` column + index, with a
+  take/pass backfill from `move.cube_action` (mirrors
+  `engine.IsResponseCubeAction`).
+
+When you add a migration, also fold the change into `001_initial_v2_7_0.sql` (so
+fresh databases get it directly), have the migration bump `database_version` in
+`metadata`, bump `domain.DatabaseVersion` if schema-visible, and extend the
+migration test.
 
 ## Multi-tenancy
 

--- a/pkg/blunderdb/storage/postgres/postgres.go
+++ b/pkg/blunderdb/storage/postgres/postgres.go
@@ -61,16 +61,9 @@ func Open(ctx context.Context, dsn string, opts *storage.Options) (*Storage, err
 	}
 
 	s := &Storage{binder: binder{db: pool}, pool: pool}
-	fresh, err := s.isFreshDB(ctx)
-	if err != nil {
+	if err := s.Migrate(ctx); err != nil {
 		pool.Close()
 		return nil, err
-	}
-	if fresh {
-		if err := bootstrap(ctx, pool); err != nil {
-			pool.Close()
-			return nil, err
-		}
 	}
 	return s, nil
 }
@@ -119,18 +112,21 @@ func (s *Storage) Version(ctx context.Context) (string, error) {
 }
 
 // Migrate brings the database up to the current schema version. A fresh
-// database is bootstrapped to the v2.7.0 schema. PostgreSQL tracks its own
-// forward migration chain and does not replay the historical SQLite chain
-// (see migrations/README.md).
+// database is bootstrapped to the v2.7.0 baseline; then any forward migrations
+// (002+) not yet recorded in schema_migrations are applied. PostgreSQL tracks
+// its own forward migration chain and does not replay the historical SQLite
+// chain (see migrations/README.md).
 func (s *Storage) Migrate(ctx context.Context) error {
 	fresh, err := s.isFreshDB(ctx)
 	if err != nil {
 		return err
 	}
 	if fresh {
-		return bootstrap(ctx, s.pool)
+		if err := bootstrap(ctx, s.pool); err != nil {
+			return err
+		}
 	}
-	return nil
+	return migrateForward(ctx, s.pool)
 }
 
 // isFreshDB reports whether the database has no schema yet (no metadata

--- a/pkg/blunderdb/storage/postgres/postgres_test.go
+++ b/pkg/blunderdb/storage/postgres/postgres_test.go
@@ -45,12 +45,13 @@ func startPostgres(t *testing.T) string {
 	return dsn
 }
 
-// wantTables is the full v2.7.0 table set, sorted.
+// wantTables is the full table set, sorted (the v2.7.0 baseline plus the
+// schema_migrations bookkeeping table created by the forward-migration runner).
 var wantTables = []string{
 	"analysis", "anki_card", "anki_deck", "collection", "collection_position",
 	"command_history", "comment", "filter_library", "game", "match",
-	"metadata", "move", "move_analysis", "position", "search_history",
-	"tournament",
+	"metadata", "move", "move_analysis", "position", "schema_migrations",
+	"search_history", "tournament",
 }
 
 // wantIndexes is the full set of named idx_* indexes, sorted.
@@ -61,14 +62,15 @@ var wantIndexes = []string{
 	"idx_anki_card_deck", "idx_anki_card_due",
 	"idx_collection_position_collection", "idx_game_match", "idx_match_canonical",
 	"idx_match_hash", "idx_move_game", "idx_move_position",
+	"idx_position_cube_response",
 	"idx_position_decision_dice", "idx_position_decision_pip",
 	"idx_position_dice", "idx_position_off", "idx_position_pip_diff",
 	"idx_position_score", "idx_position_score_cube", "idx_position_zobrist",
 }
 
 // TestMigratePostgres opens a fresh database, runs Migrate, and confirms the
-// v2.7.0 schema landed: all 16 tables, every named index, the database_version
-// row, and a tenant_id column on every domain table.
+// schema landed: all 17 tables, every named index, the database_version row,
+// and a tenant_id column on every domain table.
 func TestMigratePostgres(t *testing.T) {
 	ctx := context.Background()
 	dsn := startPostgres(t)
@@ -109,9 +111,10 @@ func TestMigratePostgres(t *testing.T) {
 		t.Errorf("indexes:\n got  %v\n want %v", indexes, wantIndexes)
 	}
 
-	// Every domain table is multi-tenant; metadata is database-level.
+	// Every domain table is multi-tenant; metadata and schema_migrations are
+	// database-level infrastructure.
 	for _, tbl := range wantTables {
-		if tbl == "metadata" {
+		if tbl == "metadata" || tbl == "schema_migrations" {
 			continue
 		}
 		var n int

--- a/pkg/blunderdb/storage/postgres/search_postgres.go
+++ b/pkg/blunderdb/storage/postgres/search_postgres.go
@@ -125,6 +125,15 @@ func (s *searchStore) find(ctx context.Context, tenant int64, f domain.SearchFil
 		if f.DecisionTypeFilter {
 			where.WriteString(" AND p.decision_type = ? AND p.player_on_roll = ?")
 			args = append(args, f.Filter.DecisionType, f.Filter.PlayerOnRoll)
+			// Cube sub-type: distinguish double/no-double from take/pass responses.
+			if f.Filter.DecisionType == domain.CubeAction {
+				switch f.CubeResponseFilter {
+				case "double":
+					where.WriteString(" AND p.is_cube_response = FALSE")
+				case "takepass":
+					where.WriteString(" AND p.is_cube_response = TRUE")
+				}
+			}
 		}
 		if f.DiceRollFilter {
 			if f.DiceRollMode == "first" {
@@ -144,6 +153,11 @@ func (s *searchStore) find(ctx context.Context, tenant int64, f domain.SearchFil
 		if f.IncludeCube {
 			if f.Filter.Cube.Value == 0 {
 				where.WriteString(" AND p.cube_value IS NULL")
+			} else if f.DecisionTypeFilter && f.CubeResponseFilter == "takepass" {
+				// A take/pass offered cube is always centered (owner -1); the board
+				// can't build a centered value>1 cube, so match the centered owner.
+				where.WriteString(" AND p.cube_value = ? AND p.cube_owner = -1")
+				args = append(args, f.Filter.Cube.Value)
 			} else {
 				where.WriteString(" AND p.cube_value = ? AND p.cube_owner = ?")
 				args = append(args, f.Filter.Cube.Value, f.Filter.Cube.Owner)
@@ -226,7 +240,7 @@ func (s *searchStore) find(ctx context.Context, tenant int64, f domain.SearchFil
 	query := `SELECT p.id, p.state,
 		p.decision_type, p.player_on_roll, p.dice_1, p.dice_2,
 		p.cube_value, p.cube_owner, p.score_1, p.score_2,
-		p.has_jacoby, p.has_beaver,
+		p.has_jacoby, p.has_beaver, p.is_cube_response,
 		a.id, a.data
 	FROM position p
 	LEFT JOIN analysis a ON a.position_id = p.id
@@ -245,12 +259,13 @@ func (s *searchStore) find(ctx context.Context, tenant int64, f domain.SearchFil
 		var posState string
 		var pDT, pPOR, pD1, pD2, pCV, pCO, pS1, pS2 *int64
 		var pHJ, pHB *bool
+		var pICR *bool
 		var anaID *int64
 		var anaData []byte
 
 		if err := rows.Scan(
 			&posID, &posState,
-			&pDT, &pPOR, &pD1, &pD2, &pCV, &pCO, &pS1, &pS2, &pHJ, &pHB,
+			&pDT, &pPOR, &pD1, &pD2, &pCV, &pCO, &pS1, &pS2, &pHJ, &pHB, &pICR,
 			&anaID, &anaData,
 		); err != nil {
 			return nil, fmt.Errorf("postgres: search scan: %w", err)
@@ -298,6 +313,17 @@ func (s *searchStore) find(ctx context.Context, tenant int64, f domain.SearchFil
 				}
 				if f.DecisionTypeFilter && !pos.MatchesDecisionType(f.Filter) {
 					return false
+				}
+				// Cube sub-type (take/pass vs double/no-double) lives in the
+				// is_cube_response column, scanned separately above.
+				if f.DecisionTypeFilter && f.Filter.DecisionType == domain.CubeAction {
+					isResp := pICR != nil && *pICR
+					if f.CubeResponseFilter == "double" && isResp {
+						return false
+					}
+					if f.CubeResponseFilter == "takepass" && !isResp {
+						return false
+					}
 				}
 				if f.DiceRollFilter && !pos.MatchesDiceRollMode(f.Filter, f.DiceRollMode) {
 					return false

--- a/pkg/blunderdb/storage/sqlite/analyses_sqlite.go
+++ b/pkg/blunderdb/storage/sqlite/analyses_sqlite.go
@@ -69,6 +69,18 @@ func (s *analysisStore) Save(ctx context.Context, scope string, positionID int64
 	if err != nil {
 		return fmt.Errorf("sqlite: save analysis: %w", err)
 	}
+
+	// Flag the position as a take/pass cube response if any played cube action is
+	// a response (only ever set to 1; OR semantics for a deduped position).
+	for _, action := range a.PlayedCubeActions {
+		if engine.IsResponseCubeAction(action) {
+			if _, err := s.db.ExecContext(ctx,
+				`UPDATE position SET is_cube_response = 1 WHERE id = ?`, positionID); err != nil {
+				return fmt.Errorf("sqlite: flag cube response: %w", err)
+			}
+			break
+		}
+	}
 	return nil
 }
 

--- a/pkg/blunderdb/storage/sqlite/schema_sqlite.go
+++ b/pkg/blunderdb/storage/sqlite/schema_sqlite.go
@@ -38,7 +38,8 @@ var schemaStatements = []string{
 		occupancy_2       INTEGER,
 		point_mask_1      INTEGER,
 		point_mask_2      INTEGER,
-		state             TEXT    NOT NULL
+		state             TEXT    NOT NULL,
+		is_cube_response  INTEGER NOT NULL DEFAULT 0
 	)`,
 	`CREATE TABLE IF NOT EXISTS analysis (
 		id                          INTEGER PRIMARY KEY,
@@ -215,6 +216,7 @@ var schemaStatements = []string{
 	`CREATE UNIQUE INDEX IF NOT EXISTS idx_position_zobrist        ON position(zobrist_hash)`,
 	`CREATE        INDEX IF NOT EXISTS idx_position_decision_pip   ON position(decision_type, pip_diff)`,
 	`CREATE        INDEX IF NOT EXISTS idx_position_decision_dice  ON position(decision_type, dice_1, dice_2)`,
+	`CREATE        INDEX IF NOT EXISTS idx_position_cube_response  ON position(decision_type, is_cube_response)`,
 	`CREATE        INDEX IF NOT EXISTS idx_position_pip_diff       ON position(pip_diff)`,
 	`CREATE        INDEX IF NOT EXISTS idx_position_dice           ON position(dice_1, dice_2)`,
 	`CREATE        INDEX IF NOT EXISTS idx_position_off            ON position(off_1, off_2)`,

--- a/pkg/blunderdb/storage/sqlite/search_sqlite.go
+++ b/pkg/blunderdb/storage/sqlite/search_sqlite.go
@@ -123,6 +123,15 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 		if f.DecisionTypeFilter {
 			where.WriteString(" AND p.decision_type = ? AND p.player_on_roll = ?")
 			args = append(args, f.Filter.DecisionType, f.Filter.PlayerOnRoll)
+			// Cube sub-type: distinguish double/no-double from take/pass responses.
+			if f.Filter.DecisionType == domain.CubeAction {
+				switch f.CubeResponseFilter {
+				case "double":
+					where.WriteString(" AND p.is_cube_response = 0")
+				case "takepass":
+					where.WriteString(" AND p.is_cube_response = 1")
+				}
+			}
 		}
 		if f.DiceRollFilter {
 			if f.DiceRollMode == "first" {
@@ -142,6 +151,11 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 		if f.IncludeCube {
 			if f.Filter.Cube.Value == 0 {
 				where.WriteString(" AND p.cube_value IS NULL")
+			} else if f.DecisionTypeFilter && f.CubeResponseFilter == "takepass" {
+				// A take/pass offered cube is always centered (owner -1); the board
+				// can't build a centered value>1 cube, so match the centered owner.
+				where.WriteString(" AND p.cube_value = ? AND p.cube_owner = -1")
+				args = append(args, f.Filter.Cube.Value)
 			} else {
 				where.WriteString(" AND p.cube_value = ? AND p.cube_owner = ?")
 				args = append(args, f.Filter.Cube.Value, f.Filter.Cube.Owner)
@@ -225,7 +239,7 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 	query := `SELECT p.id, p.state,
 		p.decision_type, p.player_on_roll, p.dice_1, p.dice_2,
 		p.cube_value, p.cube_owner, p.score_1, p.score_2,
-		p.has_jacoby, p.has_beaver,
+		p.has_jacoby, p.has_beaver, p.is_cube_response,
 		a.id, a.data,
 		a.cube_error, a.best_move_equity_error,
 		a.player1_win_rate, a.player1_gammon_rate, a.player1_backgammon_rate,
@@ -247,6 +261,7 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 		var posID int64
 		var posJSON string
 		var pDT, pPOR, pD1, pD2, pCV, pCO, pS1, pS2, pHJ, pHB sql.NullInt64
+		var pICR sql.NullInt64
 		var anaID sql.NullInt64
 		var anaJSON sql.NullString
 		var cubeError, moveError sql.NullFloat64
@@ -255,7 +270,7 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 
 		if err := rows.Scan(
 			&posID, &posJSON,
-			&pDT, &pPOR, &pD1, &pD2, &pCV, &pCO, &pS1, &pS2, &pHJ, &pHB,
+			&pDT, &pPOR, &pD1, &pD2, &pCV, &pCO, &pS1, &pS2, &pHJ, &pHB, &pICR,
 			&anaID, &anaJSON,
 			&cubeError, &moveError,
 			&p1Win, &p1Gammon, &p1BG,
@@ -307,6 +322,17 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 				}
 				if f.DecisionTypeFilter && !pos.MatchesDecisionType(f.Filter) {
 					return false
+				}
+				// Cube sub-type (take/pass vs double/no-double) lives in the
+				// is_cube_response column, scanned separately above.
+				if f.DecisionTypeFilter && f.Filter.DecisionType == domain.CubeAction {
+					isResp := pICR.Int64 == 1
+					if f.CubeResponseFilter == "double" && isResp {
+						return false
+					}
+					if f.CubeResponseFilter == "takepass" && !isResp {
+						return false
+					}
 				}
 				if f.DiceRollFilter && !pos.MatchesDiceRollMode(f.Filter, f.DiceRollMode) {
 					return false

--- a/pkg/blunderdb/storage/storagetest/contract.go
+++ b/pkg/blunderdb/storage/storagetest/contract.go
@@ -54,6 +54,7 @@ func RunContractTests(t *testing.T, factory func() storage.Storage) {
 		{"Session/SaveLoadEmpty", testSessionSaveLoad},
 		{"Session/MultiScopeIsolation", testSessionMultiScope},
 		{"Search/FilterByDecisionType", testSearchFilterByDecisionType},
+		{"Search/FilterByCubeResponse", testSearchFilterByCubeResponse},
 		{"Stats/AggregateCounts", testStatsAggregateCounts},
 		{"Tx/RollbackUndoes", testTxRollbackUndoes},
 		{"Tx/CommitPersists", testTxCommitPersists},
@@ -468,6 +469,85 @@ func testSearchFilterByDecisionType(t *testing.T, s storage.Storage) {
 	}
 	if got[0].DecisionType != domain.CheckerAction {
 		t.Errorf("filtered position DecisionType: got %d, want %d", got[0].DecisionType, domain.CheckerAction)
+	}
+}
+
+func testSearchFilterByCubeResponse(t *testing.T, s storage.Storage) {
+	ctx := context.Background()
+
+	// Two distinct cube positions (distinct boards → distinct Zobrist hashes).
+	// The take position carries a centered offered cube (owner -1, value 1), as
+	// take/pass positions are always stored.
+	takePos := cubePos()
+	takePos.Cube = domain.Cube{Owner: -1, Value: 1}
+	doublePos := cubePos()
+	doublePos.Board.Points[5] = domain.Point{Checkers: 1, Color: domain.White}
+
+	takeID, err := s.Positions().Save(ctx, "", &takePos)
+	if err != nil {
+		t.Fatalf("Save take position: %v", err)
+	}
+	doubleID, err := s.Positions().Save(ctx, "", &doublePos)
+	if err != nil {
+		t.Fatalf("Save double position: %v", err)
+	}
+	if takeID == doubleID {
+		t.Fatalf("cube positions deduped to the same id")
+	}
+
+	// The take position records a take/pass response → is_cube_response = 1.
+	if err := s.Analyses().Save(ctx, "", takeID, &domain.PositionAnalysis{
+		PlayedCubeActions: []string{"Take"},
+	}); err != nil {
+		t.Fatalf("Save take analysis: %v", err)
+	}
+	// The double position records a doubling decision → stays is_cube_response = 0.
+	if err := s.Analyses().Save(ctx, "", doubleID, &domain.PositionAnalysis{
+		PlayedCubeActions: []string{"Double"},
+	}); err != nil {
+		t.Fatalf("Save double analysis: %v", err)
+	}
+
+	search := func(sub string) []int64 {
+		f := domain.SearchFilters{DecisionTypeFilter: true, CubeResponseFilter: sub}
+		f.Filter.DecisionType = domain.CubeAction
+		f.Filter.PlayerOnRoll = takePos.PlayerOnRoll
+		var ids []int64
+		for pos, err := range s.Search().Find(ctx, "", f) {
+			if err != nil {
+				t.Fatalf("Find(%q): %v", sub, err)
+			}
+			ids = append(ids, pos.ID)
+		}
+		return ids
+	}
+
+	if got := search("takepass"); len(got) != 1 || got[0] != takeID {
+		t.Errorf("takepass filter: got %v, want [%d]", got, takeID)
+	}
+	if got := search("double"); len(got) != 1 || got[0] != doubleID {
+		t.Errorf("double filter: got %v, want [%d]", got, doubleID)
+	}
+	if got := search(""); len(got) != 2 {
+		t.Errorf("all-cube filter: got %d positions, want 2", len(got))
+	}
+
+	// IncludeCube + take/pass must match the centered offered cube (owner -1) even
+	// though the board filter sends an owned cube — the board can't construct a
+	// centered value>1 cube.
+	fc := domain.SearchFilters{DecisionTypeFilter: true, CubeResponseFilter: "takepass", IncludeCube: true}
+	fc.Filter.DecisionType = domain.CubeAction
+	fc.Filter.PlayerOnRoll = takePos.PlayerOnRoll
+	fc.Filter.Cube = domain.Cube{Owner: 0, Value: 1} // owned on the board; forced to -1 for take/pass
+	var ids []int64
+	for pos, err := range s.Search().Find(ctx, "", fc) {
+		if err != nil {
+			t.Fatalf("Find(includeCube takepass): %v", err)
+		}
+		ids = append(ids, pos.ID)
+	}
+	if len(ids) != 1 || ids[0] != takeID {
+		t.Errorf("includeCube+takepass filter: got %v, want [%d]", ids, takeID)
 	}
 }
 


### PR DESCRIPTION
## Résumé

Refonte du filtre **« Type de décision »** de la section *Affichage* du panneau de recherche : la case opaque « Inclure le type de décision » devient un contrôle explicite **Indifférent / Pions / Videau**, avec sous *Videau* un sous-choix **Tous / Double-Pas de double / Prise-Passe**.

### UX
- **Synchro bidirectionnelle** avec le board : éditer le board (dés → Pions, rectangle joueur → Videau) pilote le choix, et choisir Pions/Videau édite le board.
- **Prise/Passe** transforme le videau du board en **videau offert centré** (propriétaire -1), éditable en valeur tout en restant centré — exactement la représentation stockée. Quitter Prise/Passe réinitialise le videau à 1.
- Le videau offert n'est rendu que pour une vraie recherche take/pass (jamais à partir d'une analyse rémanente pendant l'édition) ; le board se redessine immédiatement au changement de sous-type.

### Backend
- Nouvelle colonne dénormalisée indexée **`is_cube_response`** sur `position`, remplie à l'import (`engine.IsResponseCubeAction`, sémantique OR entre matchs) et par migration.
- **`DatabaseVersion` 2.9.0 → 2.10.0** + migration SQLite `2.9.0→2.10.0`.
- Filtre SQL : checker / cube-tous / cube-double (`is_cube_response=0`) / cube-takepass (`is_cube_response=1`). Pour take/pass, *Inclure le videau* matche le videau offert centré (`cube_owner=-1`).
- **Postgres** : runner de migration forward idempotent (table `schema_migrations`) + `002_is_cube_response.sql` pour rattraper les bases existantes ; colonne ajoutée à la baseline 001 pour les bases neuves.

### Tests
- Migration (backfill 2.9.0→2.10.0), contrat storage (sous-type cube + Inclure le videau take/pass, sqlite+postgres), cohérence à l'import. Suite Go complète + 406 tests front au vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)