### PR TITLE
ci: fix govulncheck and frontend-e2e (green CI)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.25.10
+          go-version: 1.25.11
           cache: true
 
       - name: Create frontend dist stub
@@ -113,7 +113,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.25.10
+          go-version: 1.25.11
           cache: true
 
       - name: Create frontend dist stub
@@ -165,7 +165,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.25.10
+          go-version: 1.25.11
           cache: true
 
       - name: Create frontend dist stub
@@ -193,7 +193,7 @@ jobs:
       - name: govulncheck
         uses: golang/govulncheck-action@v1
         with:
-          go-version-input: 1.25.10
+          go-version-input: 1.25.11
           check-latest: true
           repo-checkout: false
 
@@ -225,7 +225,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           check-latest: true
-          go-version: 1.25.10
+          go-version: 1.25.11
           cache: true
       - run: go version
         shell: bash

--- a/frontend/tests/e2e/helpers/wailsMock.js
+++ b/frontend/tests/e2e/helpers/wailsMock.js
@@ -131,6 +131,11 @@ export async function installWailsMock(page, opts = {}) {
                     GetStatsFilter: asyncNull,
                     SaveStatsFilter: asyncVoid,
                     SaveConfig: asyncVoid,
+                    // Treat the tour as already seen so the first-run catalog modal
+                    // does not auto-open and intercept clicks. Specs that test the
+                    // tour open the catalog explicitly.
+                    GetTourSeen: () => Promise.resolve(true),
+                    SaveTourSeen: asyncVoid,
                 }),
             },
         };


### PR DESCRIPTION
Deux échecs CI préexistants sur `main`, sans rapport avec le code fonctionnel :

- **govulncheck** : bump du toolchain Go CI `1.25.10 → 1.25.11`, qui corrige les vulnérabilités stdlib signalées **GO-2026-5039** (net/textproto) et **GO-2026-5037** (crypto/x509), atteintes via `internal/server`.
- **frontend-e2e** : le catalogue de tours guidés s'ouvrait au premier lancement et son overlay interceptait les clics, faisant échouer les specs *tab-switch* et *EPC*. Mock `Config.GetTourSeen → true` dans le mock Wails e2e partagé pour que le catalogue ne s'auto-ouvre pas ; les specs qui testent le tour l'ouvrent explicitement.

Vérifié localement : les 17 tests e2e passent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)