### PR TITLE
feat(ui): adjustable interface scale in Settings

### DIFF
--- a/config.go
+++ b/config.go
@@ -86,6 +86,14 @@ func (bc BoardColors) withDefaults() BoardColors {
 	return bc
 }
 
+// UI scale bounds (percentage). The interface is rendered at UIScale% of its
+// native size; 100 means no scaling.
+const (
+	MinUIScale     = 50
+	MaxUIScale     = 200
+	DefaultUIScale = 100
+)
+
 type Config struct {
 	WindowWidth      int                  `json:"window_width"`
 	WindowHeight     int                  `json:"window_height"`
@@ -93,7 +101,23 @@ type Config struct {
 	StatsFilter      StatsFilterPersisted `json:"stats_filter,omitempty"`
 	Language         string               `json:"language,omitempty"`
 	BoardColors      BoardColors          `json:"board_colors,omitempty"`
+	UIScale          int                  `json:"ui_scale,omitempty"`
 	TourSeen         bool                 `json:"tour_seen,omitempty"`
+}
+
+// clampUIScale coerces a persisted/incoming scale into the supported range,
+// mapping the zero value (missing in older config files) to the default.
+func clampUIScale(scale int) int {
+	if scale == 0 {
+		return DefaultUIScale
+	}
+	if scale < MinUIScale {
+		return MinUIScale
+	}
+	if scale > MaxUIScale {
+		return MaxUIScale
+	}
+	return scale
 }
 
 func NewConfig() *Config {
@@ -103,6 +127,7 @@ func NewConfig() *Config {
 		WindowHeight: initialHeight,
 		Language:     "en",
 		BoardColors:  DefaultBoardColors(),
+		UIScale:      DefaultUIScale,
 	}
 }
 
@@ -157,6 +182,8 @@ func (c *Config) LoadConfig() (*Config, error) {
 	}
 	c.BoardColors = config.BoardColors.withDefaults()
 	config.BoardColors = c.BoardColors
+	c.UIScale = clampUIScale(config.UIScale)
+	config.UIScale = c.UIScale
 	c.TourSeen = config.TourSeen
 
 	return &config, nil
@@ -213,6 +240,19 @@ func (c *Config) GetBoardColors() BoardColors {
 // SaveBoardColors persists the given board palette to disk.
 func (c *Config) SaveBoardColors(colors BoardColors) error {
 	c.BoardColors = colors.withDefaults()
+	return c.SaveConfig(c)
+}
+
+// GetUIScale returns the persisted interface scale as a percentage (clamped to
+// the supported range; defaults to 100).
+func (c *Config) GetUIScale() int {
+	return clampUIScale(c.UIScale)
+}
+
+// SaveUIScale persists the given interface scale (percentage) to disk, clamped
+// to the supported range.
+func (c *Config) SaveUIScale(scale int) error {
+	c.UIScale = clampUIScale(scale)
 	return c.SaveConfig(c)
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -43,3 +43,35 @@ func TestGetBoardColorsDefaultsEmpty(t *testing.T) {
 		t.Errorf("GetBoardColors did not default empty config")
 	}
 }
+
+func TestClampUIScale(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{0, DefaultUIScale}, // missing in old config files → default
+		{100, 100},          // in range
+		{50, 50},            // lower bound
+		{200, 200},          // upper bound
+		{10, MinUIScale},    // below range → clamped up
+		{1000, MaxUIScale},  // above range → clamped down
+		{-5, MinUIScale},    // negative → clamped up
+	}
+	for _, c := range cases {
+		if got := clampUIScale(c.in); got != c.want {
+			t.Errorf("clampUIScale(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestNewConfigHasDefaultUIScale(t *testing.T) {
+	if c := NewConfig(); c.UIScale != DefaultUIScale {
+		t.Errorf("NewConfig UIScale = %d, want %d", c.UIScale, DefaultUIScale)
+	}
+}
+
+func TestGetUIScaleDefaultsEmpty(t *testing.T) {
+	// An empty config (e.g. an old file with no ui_scale) must report the default.
+	if got := (&Config{}).GetUIScale(); got != DefaultUIScale {
+		t.Errorf("GetUIScale on empty config = %d, want %d", got, DefaultUIScale)
+	}
+}

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -8,6 +8,7 @@
     import { SaveWindowDimensions, GetLastDatabasePath, SaveLastDatabasePath, GetLanguage } from '../wailsjs/go/main/Config.js';
     import { initLanguage } from './i18n';
     import { initBoardColors } from './stores/boardColorsStore';
+    import { initUIScale } from './stores/uiScaleStore';
 
     // Stores
     import { databasePathStore } from './stores/databaseStore.js';
@@ -355,6 +356,9 @@
         // Load the persisted board palette (falls back to defaults internally).
         initBoardColors();
 
+        // Apply the persisted interface scale (falls back to 100% internally).
+        initUIScale();
+
         // On first launch only, show the guided-tour catalog once.
         maybeRunFirstRunTour();
 
@@ -524,12 +528,17 @@
     .main-container {
         display: flex;
         flex-direction: column;
-        height: 100vh;
+        /* Interface scaling: `zoom` enlarges the whole UI (icons, fonts, panels,
+           modals and the SVG board, which stays crisp). The viewport units are
+           divided by the same factor so the zoomed box still fills exactly one
+           viewport — preventing scrollbars/overflow at scales other than 100%. */
+        zoom: var(--ui-scale, 1);
+        height: calc(100vh / var(--ui-scale, 1));
+        width: calc(100vw / var(--ui-scale, 1));
         padding: 0;
         box-sizing: border-box;
         position: relative;
         overflow: hidden;
-        width: 100vw;
     }
 
     .scrollable-content {

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -529,12 +529,14 @@
         display: flex;
         flex-direction: column;
         /* Interface scaling: `zoom` enlarges the whole UI (icons, fonts, panels,
-           modals and the SVG board, which stays crisp). The viewport units are
-           divided by the same factor so the zoomed box still fills exactly one
-           viewport — preventing scrollbars/overflow at scales other than 100%. */
+           modals and the SVG board, which stays crisp). The WebKit/WebView
+           engines resolve `vw`/`vh` in the zoomed coordinate system, so plain
+           100vw/100vh still fill exactly one viewport at any scale — do NOT
+           divide them by the scale (that under-sizes the box and leaves gaps
+           on the right and below the status bar). */
         zoom: var(--ui-scale, 1);
-        height: calc(100vh / var(--ui-scale, 1));
-        width: calc(100vw / var(--ui-scale, 1));
+        height: 100vh;
+        width: 100vw;
         padding: 0;
         box-sizing: border-box;
         position: relative;

--- a/frontend/src/components/ConfigModal.svelte
+++ b/frontend/src/components/ConfigModal.svelte
@@ -2,7 +2,7 @@
     import { trapFocus } from '../utils/focusTrap.js';
     import { t, language, setLanguage, LOCALES, LANGUAGE_LABELS } from '../i18n';
     import { boardColorsStore, setBoardColor, resetBoardColors } from '../stores/boardColorsStore';
-    import { uiScaleStore, setUIScale, MIN_UI_SCALE, MAX_UI_SCALE, UI_SCALE_STEP } from '../stores/uiScaleStore';
+    import { uiScaleStore, setUIScale, previewUIScale, MIN_UI_SCALE, MAX_UI_SCALE, UI_SCALE_STEP } from '../stores/uiScaleStore';
 
     let { visible = false, onClose } = $props();
 
@@ -27,6 +27,12 @@
         setBoardColor(key, event.currentTarget.value);
     }
 
+    // Live, lightweight preview while dragging (CSS zoom only)...
+    function onUIScaleInput(event) {
+        previewUIScale(Number(event.currentTarget.value));
+    }
+
+    // ...and the expensive board re-fit + persistence only once, on release.
     function onUIScaleChange(event) {
         setUIScale(Number(event.currentTarget.value));
     }
@@ -57,7 +63,17 @@
             <div class="setting-row">
                 <label for="config-ui-scale">{$t('config.uiScale')}</label>
                 <div class="scale-control">
-                    <input id="config-ui-scale" type="range" class="setting-range" min={MIN_UI_SCALE} max={MAX_UI_SCALE} step={UI_SCALE_STEP} value={$uiScaleStore} oninput={onUIScaleChange} />
+                    <input
+                        id="config-ui-scale"
+                        type="range"
+                        class="setting-range"
+                        min={MIN_UI_SCALE}
+                        max={MAX_UI_SCALE}
+                        step={UI_SCALE_STEP}
+                        value={$uiScaleStore}
+                        oninput={onUIScaleInput}
+                        onchange={onUIScaleChange}
+                    />
                     <span class="scale-value">{$uiScaleStore}%</span>
                 </div>
             </div>

--- a/frontend/src/components/ConfigModal.svelte
+++ b/frontend/src/components/ConfigModal.svelte
@@ -2,6 +2,7 @@
     import { trapFocus } from '../utils/focusTrap.js';
     import { t, language, setLanguage, LOCALES, LANGUAGE_LABELS } from '../i18n';
     import { boardColorsStore, setBoardColor, resetBoardColors } from '../stores/boardColorsStore';
+    import { uiScaleStore, setUIScale, MIN_UI_SCALE, MAX_UI_SCALE, UI_SCALE_STEP } from '../stores/uiScaleStore';
 
     let { visible = false, onClose } = $props();
 
@@ -26,6 +27,10 @@
         setBoardColor(key, event.currentTarget.value);
     }
 
+    function onUIScaleChange(event) {
+        setUIScale(Number(event.currentTarget.value));
+    }
+
     function handleKeyDown(event) {
         if (event.key === 'Escape') {
             onClose();
@@ -46,6 +51,15 @@
                         <option value={code}>{LANGUAGE_LABELS[code]}</option>
                     {/each}
                 </select>
+            </div>
+
+            <div class="section-title">{$t('config.interface')}</div>
+            <div class="setting-row">
+                <label for="config-ui-scale">{$t('config.uiScale')}</label>
+                <div class="scale-control">
+                    <input id="config-ui-scale" type="range" class="setting-range" min={MIN_UI_SCALE} max={MAX_UI_SCALE} step={UI_SCALE_STEP} value={$uiScaleStore} oninput={onUIScaleChange} />
+                    <span class="scale-value">{$uiScaleStore}%</span>
+                </div>
             </div>
 
             <div class="section-title">{$t('config.colors')}</div>
@@ -143,6 +157,26 @@
         outline: none;
         border-color: #6c757d;
         box-shadow: 0 0 5px rgba(108, 117, 125, 0.5);
+    }
+
+    .scale-control {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex: 0 0 auto;
+    }
+
+    .setting-range {
+        width: 130px;
+        cursor: pointer;
+        accent-color: #6c757d;
+    }
+
+    .scale-value {
+        min-width: 42px;
+        text-align: right;
+        font-variant-numeric: tabular-nums;
+        font-weight: 500;
     }
 
     .section-title {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Einstellungen",
         "language": "Sprache",
+        "interface": "Oberfläche",
+        "uiScale": "Oberflächenskalierung",
         "colors": "Brettfarben",
         "colorBackground": "Hintergrund",
         "colorBorder": "Rahmen",

--- a/frontend/src/i18n/locales/el.json
+++ b/frontend/src/i18n/locales/el.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Ρυθμίσεις",
         "language": "Γλώσσα",
+        "interface": "Διεπαφή",
+        "uiScale": "Κλίμακα διεπαφής",
         "colors": "Χρώματα ταμπλό",
         "colorBackground": "Φόντο",
         "colorBorder": "Περίγραμμα",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Settings",
         "language": "Language",
+        "interface": "Interface",
+        "uiScale": "Interface scale",
         "colors": "Board colours",
         "colorBackground": "Background",
         "colorBorder": "Border",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Ajustes",
         "language": "Idioma",
+        "interface": "Interfaz",
+        "uiScale": "Escala de la interfaz",
         "colors": "Colores del tablero",
         "colorBackground": "Fondo",
         "colorBorder": "Borde",

--- a/frontend/src/i18n/locales/fi.json
+++ b/frontend/src/i18n/locales/fi.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Asetukset",
         "language": "Kieli",
+        "interface": "Käyttöliittymä",
+        "uiScale": "Käyttöliittymän skaalaus",
         "colors": "Laudan värit",
         "colorBackground": "Tausta",
         "colorBorder": "Reuna",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Paramètres",
         "language": "Langue",
+        "interface": "Interface",
+        "uiScale": "Échelle de l'interface",
         "colors": "Couleurs du plateau",
         "colorBackground": "Fond",
         "colorBorder": "Bordure",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Impostazioni",
         "language": "Lingua",
+        "interface": "Interfaccia",
+        "uiScale": "Scala dell'interfaccia",
         "colors": "Colori della board",
         "colorBackground": "Sfondo",
         "colorBorder": "Bordo",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "設定",
         "language": "言語",
+        "interface": "インターフェース",
+        "uiScale": "インターフェースの倍率",
         "colors": "ボードの色",
         "colorBackground": "背景",
         "colorBorder": "枠線",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -19,6 +19,8 @@
     "config": {
         "title": "Настройки",
         "language": "Язык",
+        "interface": "Интерфейс",
+        "uiScale": "Масштаб интерфейса",
         "colors": "Цвета доски",
         "colorBackground": "Фон",
         "colorBorder": "Граница",

--- a/frontend/src/stores/uiScaleStore.js
+++ b/frontend/src/stores/uiScaleStore.js
@@ -20,12 +20,17 @@ function sanitize(scale) {
     return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, n));
 }
 
-// Push the scale into the DOM (the CSS variable consumed by .main-container)
-// and let the board re-fit, since the available layout size changes with zoom.
-function applyToDom(scale) {
+// Push the scale into the DOM via the CSS variable consumed by .main-container.
+// This is cheap (a single reflow) and is safe to call on every slider tick.
+function applyVar(scale) {
     if (typeof document === 'undefined') return;
     document.documentElement.style.setProperty('--ui-scale', String(scale / 100));
-    // two.js sizes the board from its container's client box; nudge it to refit.
+}
+
+// Ask the board to re-fit: two.js sizes itself from its container's client box,
+// which changes with zoom. This is expensive, so only call it when the scale is
+// committed (e.g. on slider release), not on every intermediate drag value.
+function requestBoardRefit() {
     if (typeof window !== 'undefined') {
         window.dispatchEvent(new Event('resize'));
     }
@@ -33,22 +38,32 @@ function applyToDom(scale) {
 
 // Load the persisted scale at startup. Falls back to the default on any error.
 export async function initUIScale() {
+    let scale = DEFAULT_UI_SCALE;
     try {
-        const persisted = sanitize(await GetUIScale());
-        uiScaleStore.set(persisted);
-        applyToDom(persisted);
+        scale = sanitize(await GetUIScale());
     } catch (err) {
         logger.error('Failed to load UI scale, using default:', err);
-        uiScaleStore.set(DEFAULT_UI_SCALE);
-        applyToDom(DEFAULT_UI_SCALE);
     }
+    uiScaleStore.set(scale);
+    applyVar(scale);
+    requestBoardRefit();
 }
 
-// Update the interface scale, apply it live and persist it.
+// Live preview while dragging: update the store + CSS zoom only. The whole UI
+// (board SVG included) scales via `zoom` for instant feedback, but the board is
+// not re-fitted and nothing is persisted until the value is committed.
+export function previewUIScale(scale) {
+    const next = sanitize(scale);
+    uiScaleStore.set(next);
+    applyVar(next);
+}
+
+// Commit the interface scale: apply it, re-fit the board once and persist it.
 export function setUIScale(scale) {
     const next = sanitize(scale);
     uiScaleStore.set(next);
-    applyToDom(next);
+    applyVar(next);
+    requestBoardRefit();
     SaveUIScale(next).catch((err) => logger.error('Failed to save UI scale:', err));
 }
 

--- a/frontend/src/stores/uiScaleStore.js
+++ b/frontend/src/stores/uiScaleStore.js
@@ -1,0 +1,58 @@
+import { writable } from 'svelte/store';
+import { GetUIScale, SaveUIScale } from '../../wailsjs/go/main/Config.js';
+import { logger } from '../utils/logger.js';
+
+// Interface scale as a percentage. The whole UI (toolbar icons, fonts, panels,
+// modals and the SVG board) is rendered at UI_SCALE% of its native size via the
+// `--ui-scale` CSS custom property and `zoom` on the main container. Bounds and
+// default mirror config.go (MinUIScale/MaxUIScale/DefaultUIScale).
+export const MIN_UI_SCALE = 50;
+export const MAX_UI_SCALE = 200;
+export const DEFAULT_UI_SCALE = 100;
+export const UI_SCALE_STEP = 10;
+
+export const uiScaleStore = writable(DEFAULT_UI_SCALE);
+
+// Coerce any value into a valid, integral percentage within bounds.
+function sanitize(scale) {
+    const n = Math.round(Number(scale));
+    if (!Number.isFinite(n) || n === 0) return DEFAULT_UI_SCALE;
+    return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, n));
+}
+
+// Push the scale into the DOM (the CSS variable consumed by .main-container)
+// and let the board re-fit, since the available layout size changes with zoom.
+function applyToDom(scale) {
+    if (typeof document === 'undefined') return;
+    document.documentElement.style.setProperty('--ui-scale', String(scale / 100));
+    // two.js sizes the board from its container's client box; nudge it to refit.
+    if (typeof window !== 'undefined') {
+        window.dispatchEvent(new Event('resize'));
+    }
+}
+
+// Load the persisted scale at startup. Falls back to the default on any error.
+export async function initUIScale() {
+    try {
+        const persisted = sanitize(await GetUIScale());
+        uiScaleStore.set(persisted);
+        applyToDom(persisted);
+    } catch (err) {
+        logger.error('Failed to load UI scale, using default:', err);
+        uiScaleStore.set(DEFAULT_UI_SCALE);
+        applyToDom(DEFAULT_UI_SCALE);
+    }
+}
+
+// Update the interface scale, apply it live and persist it.
+export function setUIScale(scale) {
+    const next = sanitize(scale);
+    uiScaleStore.set(next);
+    applyToDom(next);
+    SaveUIScale(next).catch((err) => logger.error('Failed to save UI scale:', err));
+}
+
+// Restore the default scale and persist it.
+export function resetUIScale() {
+    setUIScale(DEFAULT_UI_SCALE);
+}

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -1,3 +1,8 @@
+:root {
+    /* User-controlled interface scale (see uiScaleStore.js). 1 = 100%. */
+    --ui-scale: 1;
+}
+
 html,
 body {
     margin: 0;

--- a/frontend/wailsjs/go/main/Config.d.ts
+++ b/frontend/wailsjs/go/main/Config.d.ts
@@ -12,6 +12,8 @@ export function GetStatsFilter():Promise<main.StatsFilterPersisted>;
 
 export function GetTourSeen():Promise<boolean>;
 
+export function GetUIScale():Promise<number>;
+
 export function LoadConfig():Promise<main.Config>;
 
 export function SaveBoardColors(arg1:main.BoardColors):Promise<void>;
@@ -25,5 +27,7 @@ export function SaveLastDatabasePath(arg1:string):Promise<void>;
 export function SaveStatsFilter(arg1:main.StatsFilterPersisted):Promise<void>;
 
 export function SaveTourSeen(arg1:boolean):Promise<void>;
+
+export function SaveUIScale(arg1:number):Promise<void>;
 
 export function SaveWindowDimensions(arg1:number,arg2:number):Promise<void>;

--- a/frontend/wailsjs/go/main/Config.js
+++ b/frontend/wailsjs/go/main/Config.js
@@ -22,6 +22,10 @@ export function GetTourSeen() {
   return window['go']['main']['Config']['GetTourSeen']();
 }
 
+export function GetUIScale() {
+  return window['go']['main']['Config']['GetUIScale']();
+}
+
 export function LoadConfig() {
   return window['go']['main']['Config']['LoadConfig']();
 }
@@ -48,6 +52,10 @@ export function SaveStatsFilter(arg1) {
 
 export function SaveTourSeen(arg1) {
   return window['go']['main']['Config']['SaveTourSeen'](arg1);
+}
+
+export function SaveUIScale(arg1) {
+  return window['go']['main']['Config']['SaveUIScale'](arg1);
 }
 
 export function SaveWindowDimensions(arg1, arg2) {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1305,6 +1305,7 @@ export namespace main {
 	    stats_filter?: StatsFilterPersisted;
 	    language?: string;
 	    board_colors?: BoardColors;
+	    ui_scale?: number;
 	    tour_seen?: boolean;
 	
 	    static createFrom(source: any = {}) {
@@ -1319,6 +1320,7 @@ export namespace main {
 	        this.stats_filter = this.convertValues(source["stats_filter"], StatsFilterPersisted);
 	        this.language = source["language"];
 	        this.board_colors = this.convertValues(source["board_colors"], BoardColors);
+	        this.ui_scale = source["ui_scale"];
 	        this.tour_seen = source["tour_seen"];
 	    }
 	


### PR DESCRIPTION
Closes #50

## Summary

Adds an **"Interface scale"** setting in Settings (gear icon): a **50%–200%** slider (default 100%, step 10) that enlarges/shrinks the whole UI — toolbar icons, fonts, panels, modals and the board (rendered as SVG, so it stays crisp at any scale).

## Implementation

- **Backend** (`config.go`): new `ui_scale` field persisted in `config.yaml`, with bounds/clamping (`GetUIScale`/`SaveUIScale`), restored on startup — wiring mirrors the board-colors plumbing. Tests in `config_test.go`.
- **Frontend**: new `uiScaleStore.js` store, initialized in `App.svelte`.
- **Rendering**: `--ui-scale` CSS variable + `zoom` on `.main-container` (the WebKit/WebView engines resolve `vw`/`vh` in the zoomed coordinate system, so plain `100vw`/`100vh` fill exactly one viewport at any scale).
- **UI**: slider in `ConfigModal.svelte`. Smooth live preview while dragging (`oninput` → CSS `zoom` only); the board re-fit (two.js) and persistence are deferred to release (`onchange`) to avoid stutter.
- **i18n**: `config.interface` / `config.uiScale` keys added in all 9 languages.

## Verification

- `go build ./...`, `go vet .`, `go test .` ✅
- `npm run build` + pre-commit hook (ESLint + Prettier) ✅
- Manually tested in `wails dev`: viewport fills correctly at any scale, status bar stays pinned to the bottom, slider dragging is smooth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)