### PR TITLE
feat(ui): match-info header bar above the board (#52)

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -94,6 +94,7 @@
     // Components
     import Toolbar from './components/Toolbar.svelte';
     import Board from './components/Board.svelte';
+    import MatchInfoBar from './components/MatchInfoBar.svelte';
     import ViewTabs from './components/ViewTabs.svelte';
     import TabbedPanel from './components/TabbedPanel.svelte';
     import StatusBar from './components/StatusBar.svelte';
@@ -456,6 +457,8 @@
     />
 
     <ViewTabs />
+
+    <MatchInfoBar />
 
     <div class="body" class:side={isSidePanel}>
         <div class="scrollable-content" data-tour="board" class:exclude-structure-editing={$activeTabStore === 'search' && $searchStructureModeStore === 'exclude'}>

--- a/frontend/src/components/MatchInfoBar.svelte
+++ b/frontend/src/components/MatchInfoBar.svelte
@@ -1,0 +1,137 @@
+<script>
+    // Compact header strip shown directly above the board while reviewing a
+    // match. It is the match-mode counterpart to the (now removed) "P1 vs P2"
+    // status-bar text: in general/database position review it renders nothing,
+    // so the board stays uncluttered. Full match metadata (event, round, date,
+    // length) is fetched by id via GetMatchByID — the matchContextStore only
+    // carries the player names, and matchID is always set in match mode.
+    import { matchContextStore } from '../stores/positionStore';
+    import { GetMatchByID } from '../../wailsjs/go/database/Database.js';
+    import { boardColorsStore } from '../stores/boardColorsStore';
+    import { t } from '../i18n';
+    import { logger } from '../utils/logger.js';
+
+    let match = $state(null);
+    let loadedMatchID = $state(null);
+
+    // Fetch (and cache) the full match whenever the active match id changes.
+    $effect(() => {
+        const ctx = $matchContextStore;
+        if (!ctx.isMatchMode || !ctx.matchID) {
+            match = null;
+            loadedMatchID = null;
+            return;
+        }
+        if (ctx.matchID === loadedMatchID) return;
+        const wantID = ctx.matchID;
+        GetMatchByID(wantID)
+            .then((m) => {
+                // Ignore a stale response if the user navigated on in the meantime.
+                if ($matchContextStore.matchID === wantID) {
+                    match = m;
+                    loadedMatchID = wantID;
+                }
+            })
+            .catch((e) => {
+                logger.error('MatchInfoBar: failed to load match', e);
+                match = null;
+            });
+    });
+
+    // Prefer the live names from the context store (always present) and fall
+    // back to the fetched match.
+    let player1Name = $derived($matchContextStore.player1Name || match?.player1_name || '');
+    let player2Name = $derived($matchContextStore.player2Name || match?.player2_name || '');
+
+    function formatDate(value) {
+        if (!value) return '';
+        const d = new Date(value);
+        // Guard against Go's zero time (year 0001) and invalid dates.
+        if (isNaN(d.getTime()) || d.getFullYear() < 1900) return '';
+        const [year, month, day] = d.toLocaleDateString('sv-SE').split('-');
+        return `${year}/${month}/${day}`;
+    }
+
+    // Optional metadata fields, in display order, empties omitted.
+    let metaParts = $derived(
+        [match?.event, match?.location, match?.round, formatDate(match?.match_date), match?.match_length > 0 ? `${match.match_length}${$t('matchInfo.points')}` : '']
+            .map((s) => (s == null ? '' : String(s).trim()))
+            .filter((s) => s.length > 0)
+    );
+
+    let visible = $derived($matchContextStore.isMatchMode && !!$matchContextStore.matchID);
+</script>
+
+{#if visible}
+    <div class="match-info-bar" data-testid="match-info-bar">
+        <span class="player">
+            <span class="disc" style="background:{$boardColorsStore.checker1};"></span>
+            <span class="name">{player1Name}</span>
+        </span>
+        <span class="vs">{$t('matchInfo.vs')}</span>
+        <span class="player">
+            <span class="disc" style="background:{$boardColorsStore.checker2};"></span>
+            <span class="name">{player2Name}</span>
+        </span>
+        {#if metaParts.length > 0}
+            <span class="sep">·</span>
+            <span class="meta">{metaParts.join(' · ')}</span>
+        {/if}
+    </div>
+{/if}
+
+<style>
+    .match-info-bar {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        width: 100%;
+        box-sizing: border-box;
+        padding: 2px 10px;
+        height: 22px;
+        flex-shrink: 0;
+        background: #f7f7f7;
+        border-bottom: 1px solid #e0e0e0;
+        font-size: 12px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        color: #555;
+        user-select: none;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+
+    .player {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        flex-shrink: 0;
+    }
+
+    .disc {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        border: 1px solid #999;
+        flex-shrink: 0;
+    }
+
+    .name {
+        font-weight: 600;
+        color: #333;
+    }
+
+    .vs {
+        color: #999;
+        flex-shrink: 0;
+    }
+
+    .sep {
+        color: #bbb;
+        flex-shrink: 0;
+    }
+
+    .meta {
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+</style>

--- a/frontend/src/components/MatchPanel.svelte
+++ b/frontend/src/components/MatchPanel.svelte
@@ -505,7 +505,8 @@
         commentTextStore.set('');
         selectedMoveStore.set(null);
         statusBarModeStore.set('MATCH');
-        statusBarTextStore.set(`${match.player1_name} vs ${match.player2_name}`);
+        // Player names are shown in the match-info header bar above the board
+        // (MatchInfoBar.svelte), so the status bar no longer echoes "P1 vs P2".
 
         lastVisitedMatchStore.set({
             matchID: match.id,

--- a/frontend/src/components/TournamentPanel.svelte
+++ b/frontend/src/components/TournamentPanel.svelte
@@ -483,7 +483,8 @@
             commentTextStore.set('');
             selectedMoveStore.set(null);
             statusBarModeStore.set('MATCH');
-            statusBarTextStore.set(`${match.player1_name} vs ${match.player2_name}`);
+            // Player names are shown in the match-info header bar above the
+            // board (MatchInfoBar.svelte); no longer echoed in the status bar.
             lastVisitedMatchStore.set({
                 matchID: match.id,
                 currentIndex: startIndex,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -496,6 +496,10 @@
         "user": "Benutzer",
         "version": "Version"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "Pkt"
+    },
     "board": {
         "description": "Backgammon-Brett. Pip-Count von Spieler 1 {pip1}, Pip-Count von Spieler 2 {pip2}. {roller} ist am Zug.",
         "label": "Backgammon-Brett",

--- a/frontend/src/i18n/locales/el.json
+++ b/frontend/src/i18n/locales/el.json
@@ -496,6 +496,10 @@
         "user": "Χρήστης",
         "version": "Έκδοση"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "πτ"
+    },
     "board": {
         "description": "Ταμπλό backgammon. Μέτρηση pip Παίκτη 1 {pip1}, μέτρηση pip Παίκτη 2 {pip2}. Σειρά του {roller}.",
         "label": "Ταμπλό backgammon",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -496,6 +496,10 @@
         "user": "User",
         "version": "Version"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "pt"
+    },
     "board": {
         "description": "Backgammon board. Player 1 pip count {pip1}, Player 2 pip count {pip2}. {roller} to move.",
         "label": "Backgammon board",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -496,6 +496,10 @@
         "user": "Usuario",
         "version": "Versión"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "pts"
+    },
     "board": {
         "description": "Tablero de backgammon. Conteo de pips del jugador 1: {pip1}, conteo de pips del jugador 2: {pip2}. Le toca mover a {roller}.",
         "label": "Tablero de backgammon",

--- a/frontend/src/i18n/locales/fi.json
+++ b/frontend/src/i18n/locales/fi.json
@@ -496,6 +496,10 @@
         "user": "Käyttäjä",
         "version": "Versio"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "p"
+    },
     "board": {
         "description": "Backgammon-lauta. Pelaajan 1 pip-luku {pip1}, pelaajan 2 pip-luku {pip2}. {roller} siirtää.",
         "label": "Backgammon-lauta",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -496,6 +496,10 @@
         "user": "Utilisateur",
         "version": "Version"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "pt"
+    },
     "board": {
         "description": "Plateau de backgammon. Pipcount du joueur 1 : {pip1}, pipcount du joueur 2 : {pip2}. À {roller} de jouer.",
         "label": "Plateau de backgammon",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -496,6 +496,10 @@
         "user": "Utente",
         "version": "Versione"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "pt"
+    },
     "board": {
         "description": "Tavola da backgammon. Conteggio pip del Giocatore 1 {pip1}, conteggio pip del Giocatore 2 {pip2}. Tocca a {roller} muovere.",
         "label": "Tavola da backgammon",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -496,6 +496,10 @@
         "user": "ユーザー",
         "version": "バージョン"
     },
+    "matchInfo": {
+        "vs": "対",
+        "points": "pt"
+    },
     "board": {
         "description": "backgammon の盤面。プレイヤー 1 の pip カウント {pip1}、プレイヤー 2 の pip カウント {pip2}。{roller} の手番です。",
         "label": "backgammon の盤面",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -496,6 +496,10 @@
         "user": "Пользователь",
         "version": "Версия"
     },
+    "matchInfo": {
+        "vs": "vs",
+        "points": "оч"
+    },
     "board": {
         "description": "Доска для backgammon. Pip игрока 1: {pip1}, pip игрока 2: {pip2}. Ход {roller}.",
         "label": "Доска для backgammon",

--- a/frontend/src/services/positionService.js
+++ b/frontend/src/services/positionService.js
@@ -1118,7 +1118,8 @@ export async function toggleMatchMode() {
         commentTextStore.set('');
         selectedMoveStore.set(null);
         statusBarModeStore.set('MATCH');
-        statusBarTextStore.set(`${match.player1_name} vs ${match.player2_name}`);
+        // Player names are shown in the match-info header bar above the board
+        // (MatchInfoBar.svelte); no longer echoed in the status bar.
 
         lastVisitedMatchStore.set({
             matchID: match.id,


### PR DESCRIPTION
## Summary

Implements #52 — show the players' identities next to the board, plus the match metadata, **only while reviewing a match** so general/database position review stays uncluttered.

A compact header strip is rendered directly above the board in match mode:

`● Player 1   vs   ○ Player 2 · Event · Location · Round · date · Npt`

- Player names with small **black/white colour discs** (matching the board theme).
- Match metadata — event, location, round, date and match length — empty fields are omitted.
- The strip is **hidden outside match mode**, so nothing changes in general position review.
- The redundant `"Player 1 vs Player 2"` text is **removed from the status bar** (its previous display was unsatisfactory).

## Implementation notes

- New component `frontend/src/components/MatchInfoBar.svelte`, mounted between `ViewTabs` and the board body in `App.svelte` as a full-width strip (so it never disturbs the board's centering flexbox).
- Metadata is fetched by id via the existing `GetMatchByID` binding (cached per match), since `matchContextStore` only carries the player names — this makes it work from every match-mode entry point.
- `vs` / points-unit labels added to all nine locale files (`vs` kept as-is except Japanese `対`).
- Status-bar `vs` text removed from the three call sites (`MatchPanel`, `TournamentPanel`, `positionService`).

## Verification

- `npm run build` passes; eslint + prettier clean.
- Enter a match from the match library → header strip appears above the board with names + metadata.
- Navigate moves (incl. ones where Player 2 is on roll / board mirrors) → strip stays correct.
- Switch to general position review → no strip, status bar no longer shows "vs".

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)