### PR TITLE
feat(ui): show matches by default and start position review at the first position

### DIFF
--- a/frontend/src/components/MatchPanel.svelte
+++ b/frontend/src/components/MatchPanel.svelte
@@ -92,7 +92,11 @@
         });
     });
 
-    // Track panel open/close transitions and load data on open
+    // Track panel open/close transitions and load data on open. The panel may be
+    // open before the DB has finished loading (session restore opens the Matches
+    // tab by default, before openDatabaseByPath completes); that case is covered
+    // by the matchPanelRefreshTriggerStore bump fired once the DB is open and the
+    // session restored — see openDatabaseByPath.
     let _prevVisible = false;
     $effect(() => {
         const opened = visible; // $derived — tracked

--- a/frontend/src/components/TabbedPanel.svelte
+++ b/frontend/src/components/TabbedPanel.svelte
@@ -27,15 +27,15 @@
     let { onLoadPositionsByFilters, onCloseAnalysis, onCloseComment, onOpenCollection, onAddToFilterLibrary } = $props();
 
     let tabs = $state([
-        { id: 'analysis', labelKey: 'tabbedPanel.analysis', icon: 'analysis', shortcut: 'Ctrl+L' },
-        { id: 'comments', labelKey: 'tabbedPanel.comments', icon: 'comments', shortcut: 'Ctrl+P' },
-        { id: 'search', labelKey: 'tabbedPanel.search', icon: 'search', shortcut: 'Ctrl+F' },
-        { id: 'collections', labelKey: 'tabbedPanel.collections', icon: 'collections', shortcut: 'Ctrl+B' },
         { id: 'matches', labelKey: 'tabbedPanel.matches', icon: 'matches', shortcut: 'Ctrl+Tab' },
         { id: 'tournaments', labelKey: 'tabbedPanel.tournaments', icon: 'tournaments', shortcut: 'Ctrl+Y' },
-        { id: 'stats', labelKey: 'tabbedPanel.stats', icon: 'stats', shortcut: 'Ctrl+D' },
+        { id: 'collections', labelKey: 'tabbedPanel.collections', icon: 'collections', shortcut: 'Ctrl+B' },
+        { id: 'search', labelKey: 'tabbedPanel.search', icon: 'search', shortcut: 'Ctrl+F' },
+        { id: 'analysis', labelKey: 'tabbedPanel.analysis', icon: 'analysis', shortcut: 'Ctrl+L' },
+        { id: 'comments', labelKey: 'tabbedPanel.comments', icon: 'comments', shortcut: 'Ctrl+P' },
         { id: 'epc', labelKey: 'tabbedPanel.epc', icon: 'epc', shortcut: 'Ctrl+E' },
         { id: 'anki', labelKey: 'tabbedPanel.anki', icon: 'anki', shortcut: 'Ctrl+K' },
+        { id: 'stats', labelKey: 'tabbedPanel.stats', icon: 'stats', shortcut: 'Ctrl+D' },
         { id: 'metadata', labelKey: 'tabbedPanel.metadata', icon: 'metadata', shortcut: 'Ctrl+M' },
         { id: 'log', labelKey: 'tabbedPanel.log', icon: 'log', shortcut: '' }
     ]);

--- a/frontend/src/services/databaseService.js
+++ b/frontend/src/services/databaseService.js
@@ -6,7 +6,7 @@ import { SaveLastDatabasePath } from '../../wailsjs/go/main/Config.js';
 
 import { databasePathStore } from '../stores/databaseStore.js';
 import { analysisStore, selectedMoveStore } from '../stores/analysisStore.js';
-import { statusBarTextStore, statusBarModeStore, commentTextStore, openModal, closeModal, MODAL } from '../stores/uiStore.js';
+import { statusBarTextStore, statusBarModeStore, commentTextStore, openModal, closeModal, MODAL, matchPanelRefreshTriggerStore } from '../stores/uiStore.js';
 import { ankiDecksStore, selectedAnkiDeckStore, ankiReviewCardStore, ankiDeckStatsStore, ankiViewModeStore } from '../stores/ankiStore.js';
 import { logger } from '../utils/logger.js';
 // NOTE: these UI messages are translated at emission time via the non-reactive
@@ -171,6 +171,15 @@ export async function openDatabaseByPath(filePath) {
         setStatusBarMessage(tMsg('commands.dbOpened'));
         const filename = getFilenameFromPath(filePath);
         WindowSetTitle(`blunderDB - ${filename}`);
+
+        // The Matches panel may already be visible (it is the default tab,
+        // opened at mount before the DB finished loading), so its own
+        // open-transition load won't have fired against the now-open DB. Bump
+        // the refresh trigger so it loads the match list — same mechanism used
+        // after an import. Do this BEFORE restoreSessionState (which loads all
+        // positions and can be slow) so the match list appears promptly, in
+        // parallel with the restore rather than serialised after it.
+        matchPanelRefreshTriggerStore.update((n) => n + 1);
 
         const { restoreSessionState } = await import('./sessionService.js');
         await restoreSessionState();

--- a/frontend/src/services/positionService.js
+++ b/frontend/src/services/positionService.js
@@ -300,8 +300,8 @@ export async function loadAllPositions() {
         positionsStore.set(Array.isArray(positions) ? positions : []);
         if (positions && positions.length > 0) {
             currentPositionIndexStore.set(-1);
-            currentPositionIndexStore.set(positions.length - 1);
-            activeTabStore.set('analysis');
+            currentPositionIndexStore.set(0);
+            activeTabStore.set('matches');
 
             hasActiveSearch = false;
             lastSearchCommand = '';

--- a/frontend/src/stores/uiStore.js
+++ b/frontend/src/stores/uiStore.js
@@ -10,7 +10,7 @@ export const commentTextStore = writable('');
 export const analysisDataStore = writable('This is where your analysis data will be displayed.');
 
 // Active tab in the bottom panel ('log', 'analysis', 'comments', 'filter-library', 'search', 'search-history', 'collections', 'matches', 'tournaments')
-export const activeTabStore = writable('analysis');
+export const activeTabStore = writable('matches');
 
 // Session log entries: array of { timestamp, type, message }
 // type: 'info' (default), 'command', 'result', 'error'

--- a/frontend/src/stores/viewStore.js
+++ b/frontend/src/stores/viewStore.js
@@ -52,7 +52,7 @@ function createDefaultView(id) {
         position: createDefaultPosition(),
         analysis: createDefaultAnalysis(),
         selectedMove: null,
-        activeTab: 'analysis',
+        activeTab: 'matches',
         commentText: '',
         mode: 'NORMAL',
         matchContext: createDefaultMatchContext()
@@ -98,7 +98,7 @@ function createViewStore() {
         // enterEPCMode() / enterEditMode() once the DB is fully open.
         const mode = view.mode || 'NORMAL';
         statusBarModeStore.set(mode === 'EPC' || mode === 'EDIT' ? 'NORMAL' : mode);
-        activeTabStore.set(view.activeTab || 'analysis');
+        activeTabStore.set(view.activeTab || 'matches');
         commentTextStore.set(view.commentText || '');
         matchContextStore.set(view.matchContext || createDefaultMatchContext());
         currentPositionIndexStore.set(-1);


### PR DESCRIPTION
## Context

Fixes #51. When switching to analysis/review mode, the board showed the **last**
position of the database (which happens to be the last position of the last
imported match), making it look like you were reviewing a match when you were
not. This was the only entry point that started at the end: search starts at the
first match, and match mode starts at the beginning of the match.

## What changed

- **Position fallback (`positionService.js`).** When there is no session to
  restore, general position review now falls back to the **first** position
  (index 0) instead of the last. The last *visited* position is still restored
  automatically via the session, so reopening a database lands where you left
  off; only the no-session fallback changed.
- **Panel order + default tab (`TabbedPanel.svelte`, `uiStore.js`,
  `viewStore.js`, `positionService.js`).** The tabbed panel is reordered to put
  match-centric tabs first — `matches, tournaments, collections, search,
  analysis, comments, epc, anki, stats, metadata, log` — and the default active
  tab is now **Matches**, so opening a database surfaces the match list and
  guides the user toward proper match review.
- **Prompt match list load (`databaseService.js`, `MatchPanel.svelte`).** The
  Matches panel is opened by default before the database has finished loading,
  so its open-transition load would otherwise miss. The match list is now
  refreshed as soon as the DB is open — before the slower session restore — so
  it appears promptly, in parallel with the restore rather than serialised after
  it.

## Testing

- `npm test` (frontend) — 406 passing.
- Manual: open a database with no prior session → first position shown; navigate,
  reopen → last visited position restored; Matches tab active with the list
  visible on open; database with no matches → empty list, no error.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)