### PR TITLE
fix(windows): blank space at bottom of window with DPI scaling > 100%

### DIFF
--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -510,12 +510,12 @@
     .main-container {
         display: flex;
         flex-direction: column;
-        height: 100vh;
+        width: 100%;
+        height: 100%;
         padding: 0;
         box-sizing: border-box;
         position: relative;
         overflow: hidden;
-        width: 100vw;
     }
 
     .scrollable-content {

--- a/frontend/src/style.css
+++ b/frontend/src/style.css
@@ -4,7 +4,7 @@ body {
     padding: 0;
     width: 100%;
     height: 100%;
-    overflow-x: hidden; /* Prevents horizontal overflow */
+    overflow: hidden;
 }
 
 html {
@@ -53,6 +53,6 @@ body {
 }
 
 #app {
-    height: 100vh;
+    height: 100%;
     text-align: center;
 }

--- a/internal/gui/run.go
+++ b/internal/gui/run.go
@@ -7,6 +7,7 @@ import (
 	"github.com/wailsapp/wails/v2/pkg/options"
 	"github.com/wailsapp/wails/v2/pkg/options/assetserver"
 	"github.com/wailsapp/wails/v2/pkg/options/linux"
+	"github.com/wailsapp/wails/v2/pkg/options/windows"
 )
 
 // Run starts the Wails GUI. The caller supplies the embedded frontend assets
@@ -33,6 +34,11 @@ func Run(assets embed.FS, icon []byte, width, height int, extraBinds []interface
 			WindowIsTranslucent: false,
 			WebviewGpuPolicy:    linux.WebviewGpuPolicyNever,
 			ProgramName:         "blunderDB",
+		},
+		Windows: &windows.Options{
+			WebviewIsTransparent: false,
+			IsZoomControlEnabled: true,
+			ZoomFactor:           1.0,
 		},
 		Debug: options.Debug{
 			OpenInspectorOnStartup: false,


### PR DESCRIPTION
## Summary

- Replaces `height: 100vh` / `width: 100vw` with `height: 100%` / `width: 100%` across the full CSS chain (`html → body → #app → .main-container`) — percentage-based heights use the parent's actual render surface rather than CSS viewport units, which WebView2 reports incorrectly under Windows DPI scaling.
- Tightens `overflow-x: hidden` to `overflow: hidden` on `html`/`body` to eliminate any residual scroll edge case.
- Adds a `Windows: &windows.Options{}` block in `run.go` (mirrors the existing `Linux` block) with `IsZoomControlEnabled: true, ZoomFactor: 1.0` to prevent WebView2 from applying an extra zoom on top of the OS DPI factor.

## Root cause

On Windows with display scaling > 100% (e.g. 125%), WebView2 reports CSS viewport units (`vh`/`vw`) relative to **logical** pixels, while the actual render surface is larger (**physical** pixels). With a 125% DPI factor the app content filled only ~80% of the window height, leaving a blank grey area at the bottom — exactly the behaviour visible in the attached screenshot.

## Test plan

- [ ] Build the Windows binary and run on a machine with display scaling set to 125% or 150% — verify no blank space at the bottom of the window.
- [ ] Verify layout is unchanged on Linux and macOS (no regression).
- [ ] Resize the window on Windows — verify the content tracks the window edges cleanly.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)