### PR TITLE
feat(matches): matches.movesByMatch — tous les coups d'un match en un appel

### DIFF
--- a/internal/server/handlers_matches.go
+++ b/internal/server/handlers_matches.go
@@ -98,6 +98,9 @@ func (s *Server) matchRoutes() []route {
 		{http.MethodPost, "/v1/matches.moves", rpcStream(func(ctx context.Context, scope string, req gameIDReq) iterMoves {
 			return ms().Moves(ctx, scope, req.GameID)
 		})},
+		{http.MethodPost, "/v1/matches.movesByMatch", rpcStream(func(ctx context.Context, scope string, req matchIDReq) iterMoves {
+			return ms().MovesByMatch(ctx, scope, req.MatchID)
+		})},
 		{http.MethodPost, "/v1/matches.movePositions", rpcStream(func(ctx context.Context, scope string, req matchIDReq) iterMovePos {
 			return ms().MovePositions(ctx, scope, req.MatchID)
 		})},

--- a/pkg/blunderdb/storage/matches.go
+++ b/pkg/blunderdb/storage/matches.go
@@ -63,6 +63,12 @@ type MatchStore interface {
 	// Moves streams the moves of a game in order.
 	Moves(ctx context.Context, scope string, gameID int64) iter.Seq2[*domain.Move, error]
 
+	// MovesByMatch streams every move of a match in one pass, ordered by game
+	// then move number. It lets a caller render a whole match detail without the
+	// 1+N round-trips of calling Moves once per game (each move carries GameID so
+	// the caller regroups by game). Mirrors MovePositions' match-scoped shape.
+	MovesByMatch(ctx context.Context, scope string, matchID int64) iter.Seq2[*domain.Move, error]
+
 	// MovePositions streams the positions of a match together with their
 	// game/move context.
 	MovePositions(ctx context.Context, scope string, matchID int64) iter.Seq2[*domain.MatchMovePosition, error]

--- a/pkg/blunderdb/storage/postgres/matches_postgres.go
+++ b/pkg/blunderdb/storage/postgres/matches_postgres.go
@@ -519,6 +519,48 @@ func (s *matchStore) Moves(ctx context.Context, scope string, gameID int64) iter
 	}
 }
 
+// MovesByMatch streams every move of a match in chronological order (by game,
+// then move). One query instead of Games + a Moves call per game: callers
+// regroup by Move.GameID. Mirrors Moves' columns and MovePositions' match join.
+func (s *matchStore) MovesByMatch(ctx context.Context, scope string, matchID int64) iter.Seq2[*domain.Move, error] {
+	return func(yield func(*domain.Move, error) bool) {
+		rows, err := s.db.Query(ctx,
+			`SELECT mv.id, mv.game_id, COALESCE(mv.move_number,0), COALESCE(mv.move_type,''),
+			        mv.position_id, COALESCE(mv.player,0),
+			        COALESCE(mv.dice_1,0), COALESCE(mv.dice_2,0),
+			        COALESCE(mv.checker_move,''), COALESCE(mv.cube_action,'')
+			 FROM move mv INNER JOIN game g ON mv.game_id = g.id
+			 WHERE g.match_id = $1 AND mv.tenant_id = $2
+			 ORDER BY g.game_number, mv.move_number`,
+			matchID, tenantID(scope))
+		if err != nil {
+			yield(nil, fmt.Errorf("postgres: list moves by match: %w", err))
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var mv domain.Move
+			var d1, d2 int32
+			var positionID *int64
+			if err := rows.Scan(&mv.ID, &mv.GameID, &mv.MoveNumber, &mv.MoveType,
+				&positionID, &mv.Player, &d1, &d2, &mv.CheckerMove, &mv.CubeAction); err != nil {
+				yield(nil, fmt.Errorf("postgres: list moves by match: %w", err))
+				return
+			}
+			mv.Dice = [2]int32{d1, d2}
+			if positionID != nil {
+				mv.PositionID = *positionID
+			}
+			if !yield(&mv, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(nil, fmt.Errorf("postgres: list moves by match: %w", err))
+		}
+	}
+}
+
 // xgPlayerToBlunderDB maps the XG move-player encoding (1 / -1) stored in the
 // move table to the blunderDB encoding (0 = player 1, 1 = player 2). GnuBG
 // imports are stored already converted to the XG encoding, so this one mapping

--- a/pkg/blunderdb/storage/postgres/matches_postgres_test.go
+++ b/pkg/blunderdb/storage/postgres/matches_postgres_test.go
@@ -41,6 +41,16 @@ func savePos(t *testing.T, s *pg.Storage, decision int) int64 {
 	return id
 }
 
+// mustMove stores a move, failing the test on error.
+func mustMove(t *testing.T, s *pg.Storage, mv domain.Move) int64 {
+	t.Helper()
+	id, err := s.Matches().CreateMove(context.Background(), "", &mv)
+	if err != nil {
+		t.Fatalf("CreateMove: %v", err)
+	}
+	return id
+}
+
 // TestMatchSaveGetList exercises the header CRUD path.
 func TestMatchSaveGetList(t *testing.T) {
 	ctx := context.Background()
@@ -186,6 +196,47 @@ func TestMatchGamesAndMoves(t *testing.T) {
 	}
 	if moves[0].CheckerMove != "8/5 6/5" || moves[0].Dice != [2]int32{3, 1} || moves[0].PositionID != posID {
 		t.Errorf("Moves content: %+v", moves[0])
+	}
+}
+
+// TestMatchMovesByMatch verifies the one-pass move stream of a multi-game match
+// is ordered by game then move and tags each move with its game.
+func TestMatchMovesByMatch(t *testing.T) {
+	ctx := context.Background()
+	s, _ := openMatchStore(t)
+
+	m := domain.Match{Player1Name: "Alice", Player2Name: "Bob"}
+	matchID, _ := s.Matches().Save(ctx, "", &m)
+
+	g1 := domain.Game{MatchID: matchID, GameNumber: 1}
+	g1ID, _ := s.Matches().CreateGame(ctx, "", &g1)
+	g2 := domain.Game{MatchID: matchID, GameNumber: 2}
+	g2ID, _ := s.Matches().CreateGame(ctx, "", &g2)
+
+	// Insert across games and out of move order to prove the ORDER BY.
+	mustMove(t, s, domain.Move{GameID: g2ID, MoveNumber: 1, MoveType: "checker", CheckerMove: "g2m1"})
+	mustMove(t, s, domain.Move{GameID: g1ID, MoveNumber: 2, MoveType: "checker", CheckerMove: "g1m2"})
+	mustMove(t, s, domain.Move{GameID: g1ID, MoveNumber: 1, MoveType: "checker", CheckerMove: "g1m1"})
+
+	moves := collect(t, s.Matches().MovesByMatch(ctx, "", matchID))
+	if len(moves) != 3 {
+		t.Fatalf("MovesByMatch count: got %d, want 3", len(moves))
+	}
+	// game 1 (moves 1,2) before game 2 (move 1).
+	want := []struct {
+		game int64
+		cm   string
+	}{{g1ID, "g1m1"}, {g1ID, "g1m2"}, {g2ID, "g2m1"}}
+	for i, w := range want {
+		if moves[i].GameID != w.game || moves[i].CheckerMove != w.cm {
+			t.Errorf("move %d: got game=%d cm=%q, want game=%d cm=%q",
+				i, moves[i].GameID, moves[i].CheckerMove, w.game, w.cm)
+		}
+	}
+
+	// Unknown match → empty stream, no error.
+	if got := collect(t, s.Matches().MovesByMatch(ctx, "", 9999)); len(got) != 0 {
+		t.Errorf("MovesByMatch on missing match: got %d moves, want 0", len(got))
 	}
 }
 

--- a/pkg/blunderdb/storage/sqlite/matches_sqlite.go
+++ b/pkg/blunderdb/storage/sqlite/matches_sqlite.go
@@ -500,6 +500,47 @@ func (s *matchStore) Moves(ctx context.Context, scope string, gameID int64) iter
 	}
 }
 
+// MovesByMatch streams every move of a match in chronological order (by game,
+// then move). One query instead of Games + a Moves call per game: callers
+// regroup by Move.GameID. Single-tenant store, so scope is ignored (as in Moves).
+func (s *matchStore) MovesByMatch(ctx context.Context, scope string, matchID int64) iter.Seq2[*domain.Move, error] {
+	return func(yield func(*domain.Move, error) bool) {
+		rows, err := s.db.QueryContext(ctx,
+			`SELECT mv.id, COALESCE(mv.game_id,0), COALESCE(mv.move_number,0), COALESCE(mv.move_type,''),
+			        mv.position_id, COALESCE(mv.player,0),
+			        COALESCE(mv.dice_1,0), COALESCE(mv.dice_2,0),
+			        COALESCE(mv.checker_move,''), COALESCE(mv.cube_action,'')
+			 FROM move mv INNER JOIN game g ON mv.game_id = g.id
+			 WHERE g.match_id = ?
+			 ORDER BY g.game_number, mv.move_number`, matchID)
+		if err != nil {
+			yield(nil, fmt.Errorf("sqlite: list moves by match: %w", err))
+			return
+		}
+		defer rows.Close()
+		for rows.Next() {
+			var mv domain.Move
+			var d1, d2 int32
+			var positionID sql.NullInt64
+			if err := rows.Scan(&mv.ID, &mv.GameID, &mv.MoveNumber, &mv.MoveType,
+				&positionID, &mv.Player, &d1, &d2, &mv.CheckerMove, &mv.CubeAction); err != nil {
+				yield(nil, fmt.Errorf("sqlite: list moves by match: %w", err))
+				return
+			}
+			mv.Dice = [2]int32{d1, d2}
+			if positionID.Valid {
+				mv.PositionID = positionID.Int64
+			}
+			if !yield(&mv, nil) {
+				return
+			}
+		}
+		if err := rows.Err(); err != nil {
+			yield(nil, fmt.Errorf("sqlite: list moves by match: %w", err))
+		}
+	}
+}
+
 // xgPlayerToBlunderDB maps the XG move-player encoding (1 / -1) stored in the
 // move table to the blunderDB encoding (0 = player 1, 1 = player 2). GnuBG
 // imports are stored already converted to the XG encoding.

--- a/pkg/blunderdb/storage/sqlite/matches_sqlite_test.go
+++ b/pkg/blunderdb/storage/sqlite/matches_sqlite_test.go
@@ -172,3 +172,62 @@ func TestMatchLastVisited(t *testing.T) {
 		t.Errorf("LastVisited: got match %d pos %d, want %d pos 4", lv.ID, lv.LastVisitedPosition, id1)
 	}
 }
+
+// TestMatchMovesByMatch checks the one-pass, game-then-move ordered stream of a
+// multi-game match (single-tenant SQLite backend, Desktop path).
+func TestMatchMovesByMatch(t *testing.T) {
+	ctx := context.Background()
+	s := openMem(t)
+
+	m := domain.Match{Player1Name: "Alice", Player2Name: "Bob"}
+	matchID, _ := s.Matches().Save(ctx, "", &m)
+	g1 := domain.Game{MatchID: matchID, GameNumber: 1}
+	g1ID, _ := s.Matches().CreateGame(ctx, "", &g1)
+	g2 := domain.Game{MatchID: matchID, GameNumber: 2}
+	g2ID, _ := s.Matches().CreateGame(ctx, "", &g2)
+
+	// Insert across games and out of move order to prove the ORDER BY.
+	for _, mv := range []domain.Move{
+		{GameID: g2ID, MoveNumber: 1, MoveType: "checker", CheckerMove: "g2m1"},
+		{GameID: g1ID, MoveNumber: 2, MoveType: "checker", CheckerMove: "g1m2"},
+		{GameID: g1ID, MoveNumber: 1, MoveType: "checker", CheckerMove: "g1m1"},
+	} {
+		mv := mv
+		if _, err := s.Matches().CreateMove(ctx, "", &mv); err != nil {
+			t.Fatalf("CreateMove: %v", err)
+		}
+	}
+
+	var moves []domain.Move
+	for mv, err := range s.Matches().MovesByMatch(ctx, "", matchID) {
+		if err != nil {
+			t.Fatalf("MovesByMatch: %v", err)
+		}
+		moves = append(moves, *mv)
+	}
+	if len(moves) != 3 {
+		t.Fatalf("MovesByMatch count: got %d, want 3", len(moves))
+	}
+	want := []struct {
+		game int64
+		cm   string
+	}{{g1ID, "g1m1"}, {g1ID, "g1m2"}, {g2ID, "g2m1"}}
+	for i, w := range want {
+		if moves[i].GameID != w.game || moves[i].CheckerMove != w.cm {
+			t.Errorf("move %d: got game=%d cm=%q, want game=%d cm=%q",
+				i, moves[i].GameID, moves[i].CheckerMove, w.game, w.cm)
+		}
+	}
+
+	// Unknown match → empty stream, no error.
+	n := 0
+	for _, err := range s.Matches().MovesByMatch(ctx, "", 9999) {
+		if err != nil {
+			t.Fatalf("MovesByMatch missing: %v", err)
+		}
+		n++
+	}
+	if n != 0 {
+		t.Errorf("MovesByMatch on missing match: got %d moves, want 0", n)
+	}
+}


### PR DESCRIPTION
## Objectif

Ajoute un endpoint **`matches.movesByMatch(matchId)`** qui renvoie en **un seul appel** tous les coups d'un match (flux ordonné `game_number, move_number`), chaque coup portant son `GameID` pour le regroupement côté appelant.

## Pourquoi

La vue détail d'un match charge aujourd'hui les parties (`matches.games`) puis **un `matches.moves` par partie** → **1 + N** appels pour un match de N parties (un match long en compte 20+). Ce nouvel endpoint ramène ce coût à **un seul appel** (2 avec `matches.games`).

Intérêt **partagé moteur** :
- **gammonGo** (backend Postgres) : supprime le N+1 de `libraryGetMatchHandler`.
- **Desktop** (backend SQLite) : même vue détail de match, même 1+N à résoudre → la capacité est ajoutée aux **deux** implémentations.

C'est le symétrique exact de `matches.movePositions`, déjà présent et match-scoped.

## Changements

- `MatchStore.MovesByMatch(ctx, scope, matchID)` (interface) ;
- impl **Postgres** (filtre `tenant_id`) et **SQLite** (mono-tenant, `scope` ignoré comme `Moves`) — `move mv INNER JOIN game g ON mv.game_id = g.id WHERE g.match_id = ? ORDER BY g.game_number, mv.move_number` ;
- route RPC `POST /v1/matches.movesByMatch` (`rpcStream` + `iterMoves` + `matchIDReq`) ;
- tests storage postgres + sqlite (ordre cross-parties, regroupement par partie, match inconnu → flux vide).

Aucune migration (réutilise les tables `move`/`game` et leurs index PK).

## Tests

`go test ./internal/server/ ./pkg/blunderdb/storage/sqlite/` ✅ ; `go test -tags postgres ./pkg/blunderdb/storage/postgres/` ✅ (conteneur éphémère).

🤖 Generated with [Claude Code](https://claude.com/claude-code)