### PR TITLE
refactor(frontend): replace subscribe-then-unsub with get() in TournamentPanel

### DIFF
--- a/frontend/src/components/TournamentPanel.svelte
+++ b/frontend/src/components/TournamentPanel.svelte
@@ -375,9 +375,7 @@
             }
 
             // If we are currently viewing this match in match mode, update context
-            let currentContext = null;
-            const unsub = matchContextStore.subscribe((v) => (currentContext = v));
-            unsub();
+            const currentContext = get(matchContextStore);
             if (currentContext && currentContext.isMatchMode && currentContext.matchID === match.id) {
                 const movePositions = await GetMatchMovePositions(match.id);
                 if (movePositions && movePositions.length > 0) {
@@ -410,9 +408,7 @@
             }
 
             let startIndex = 0;
-            let lastVisitedMatch = null;
-            const unsub = lastVisitedMatchStore.subscribe((v) => (lastVisitedMatch = v));
-            unsub();
+            const lastVisitedMatch = get(lastVisitedMatchStore);
             // First check in-memory store for same session, then check DB-persisted value
             if (lastVisitedMatch && lastVisitedMatch.matchID === match.id) {
                 if (lastVisitedMatch.currentIndex >= 0 && lastVisitedMatch.currentIndex < movePositions.length) {


### PR DESCRIPTION
## Why

The CLAUDE.md Svelte 5 rule forbids `.subscribe()` inside components. Two call sites in `TournamentPanel.svelte` (`swapMatchPlayers`, `openMatch`) used the `store.subscribe(v => x = v); unsub()` antipattern purely to read a store's current value.

## What

Replaced both with `get(store)` (already imported). Pure read of the current value — no behaviour change. All 475 frontend tests pass.

## Note on the other 4 "violations"

The audit flagged 6 `.subscribe()` sites; the 4 in `Board.svelte` are **intentionally left as-is**. They are documented, justified exceptions: the board renders to a `two.js` canvas imperatively and needs **synchronous** redraws. A deferred `$effect` would race `drawBoard()` against arrow rendering — the exact bug the inline comments (and the project's reactivity history) warn about. CLAUDE.md explicitly permits justified exceptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)