### PR TITLE
refactor(frontend): extract SearchPanel token-parsing into a tested service fn

### DIFF
--- a/frontend/src/__tests__/searchFilterService.test.js
+++ b/frontend/src/__tests__/searchFilterService.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
-import { buildFilterTokens, buildSearchCommand } from '../services/searchFilterService.js';
+import { buildFilterTokens, buildSearchCommand, parseFilterTokens } from '../services/searchFilterService.js';
 
 // buildFilterTokens/buildSearchCommand are pure (no Wails imports), but the
 // round-trip block below imports commandProcessor's parseFilters, which pulls in
@@ -273,5 +273,74 @@ describe('round-trip against parseFilters', () => {
         expect(parsed.player1OutfieldBlotFilter).toBe('bo>1');
         expect(parsed.player1JanBlotFilter).toBe('bj>1');
         expect(parsed.player2BackgammonRateFilter).toBe('B>3');
+    });
+});
+
+describe('parseFilterTokens', () => {
+    test('extracts includes-based boolean flags', () => {
+        const p = parseFilterTokens(['cube', 'score', 'nc', 'M', 'd']);
+        expect(p.incCube).toBe(true);
+        expect(p.incScore).toBe(true);
+        expect(p.ncFilter).toBe(true);
+        expect(p.mirFilter).toBe(true);
+        expect(p.dtFilter).toBe(true);
+    });
+
+    test('defaults are false / undefined when no tokens match', () => {
+        const p = parseFilterTokens([]);
+        expect(p.incCube).toBe(false);
+        expect(p.ncFilter).toBe(false);
+        expect(p.pcFilter).toBeUndefined();
+        expect(p.cdFilter).toBeUndefined();
+        expect(p.matchIDs).toBe('');
+        expect(p.tournamentIDs).toBe('');
+        expect(p.drFilter).toBe(false);
+        expect(p.drMode).toBe('both');
+    });
+
+    test('disambiguates b-prefixed tokens: backgammon-rate vs outfield-blot vs jan-blot', () => {
+        const p = parseFilterTokens(['b>2', 'bo>1', 'bj>1', 'B>3', 'BO>1', 'BJ>1']);
+        expect(p.bgFilter).toBe('b>2'); // not bo>1 / bj>1
+        expect(p.p1obFilter).toBe('bo>1');
+        expect(p.p1jbFilter).toBe('bj>1');
+        expect(p.p2bgFilter).toBe('B>3'); // not BO>1 / BJ>1
+        expect(p.p2obFilter).toBe('BO>1');
+        expect(p.p2jbFilter).toBe('BJ>1');
+    });
+
+    test('distinguishes lowercase pip-count (p) from uppercase absolute-pip (P)', () => {
+        const p = parseFilterTokens(['p>12', 'P>50']);
+        expect(p.pcFilter).toBe('p>12');
+        expect(p.p1apcFilter).toBe('P>50');
+    });
+
+    test('double token D selects both rolls, D1 selects first roll', () => {
+        expect(parseFilterTokens(['D']).drFilter).toBe(true);
+        expect(parseFilterTokens(['D']).drMode).toBe('both');
+        const first = parseFilterTokens(['D1']);
+        expect(first.drFilter).toBe(true);
+        expect(first.drMode).toBe('first');
+    });
+
+    test('strips the 2-char prefix from match (ma) and tournament (tn) id tokens', () => {
+        const p = parseFilterTokens(['ma3,4,5', 'tn7']);
+        expect(p.matchIDs).toBe('3,4,5');
+        expect(p.tournamentIDs).toBe('7');
+    });
+
+    test('round-trips with buildFilterTokens for a representative filter set', () => {
+        const tokens = buildFilterTokens(['Equity (millipoints)', 'Move Error (millipoints, Player 1)', 'Player Checker-Off'], {
+            equityOption: 'range',
+            equityRangeMin: 10,
+            equityRangeMax: 50,
+            moveErrorOption: 'min',
+            moveErrorMin: 5,
+            player1CheckerOffOption: 'min',
+            player1CheckerOffMin: 2
+        });
+        const p = parseFilterTokens(tokens);
+        expect(p.eqFilter).toBe('e10,50');
+        expect(p.meFilter).toBe('E>5');
+        expect(p.p1coFilter).toBe('o>2');
     });
 });

--- a/frontend/src/components/SearchPanel.svelte
+++ b/frontend/src/components/SearchPanel.svelte
@@ -6,7 +6,7 @@
     import { positionStore, positionsStore, positionBeforeFilterLibraryStore, positionIndexBeforeFilterLibraryStore } from '../stores/positionStore';
     import { searchExcludePositionStore, searchStructureModeStore, searchOfferedCubeStore, emptySearchBoardPosition, boardHasCheckers } from '../stores/searchExcludePositionStore';
     import { searchHistoryStore } from '../stores/searchHistoryStore';
-    import { buildFilterTokens, buildSearchCommand } from '../services/searchFilterService.js';
+    import { buildFilterTokens, buildSearchCommand, parseFilterTokens } from '../services/searchFilterService.js';
     import { filterLibraryStore } from '../stores/filterLibraryStore';
     import { searchParamsStore } from '../stores/searchParamsStore';
     import { databaseLoadedStore } from '../stores/databaseStore';
@@ -560,38 +560,38 @@
             transformedFilters.push(cubeSubType === 'takepass' ? 'dr' : 'dd');
         }
 
-        const incCube = transformedFilters.includes('cube');
-        const incScore = transformedFilters.includes('score');
-        const ncFilter = transformedFilters.includes('nc');
-        const mirFilter = transformedFilters.includes('M');
-        const pcFilter = transformedFilters.find((f) => f.startsWith('p'));
-        const wrFilter = transformedFilters.find((f) => f.startsWith('w'));
-        const grFilter = transformedFilters.find((f) => f.startsWith('g'));
-        const bgFilter = transformedFilters.find((f) => f.startsWith('b') && !f.startsWith('bo') && !f.startsWith('bj'));
-        const p2wrFilter = transformedFilters.find((f) => f.startsWith('W'));
-        const p2grFilter = transformedFilters.find((f) => f.startsWith('G'));
-        const p2bgFilter = transformedFilters.find((f) => f.startsWith('B') && !f.startsWith('BO') && !f.startsWith('BJ'));
-        const p1coFilter = transformedFilters.find((f) => f.startsWith('o'));
-        const p2coFilter = transformedFilters.find((f) => f.startsWith('O'));
-        const p1bcFilter = transformedFilters.find((f) => f.startsWith('k'));
-        const p2bcFilter = transformedFilters.find((f) => f.startsWith('K'));
-        const p1czFilter = transformedFilters.find((f) => f.startsWith('z'));
-        const p2czFilter = transformedFilters.find((f) => f.startsWith('Z'));
-        const p1apcFilter = transformedFilters.find((f) => f.startsWith('P'));
-        const eqFilter = transformedFilters.find((f) => f.startsWith('e'));
-        const meFilter = transformedFilters.find((f) => f.startsWith('E'));
-        const p1obFilter = transformedFilters.find((f) => f.startsWith('bo'));
-        const p2obFilter = transformedFilters.find((f) => f.startsWith('BO'));
-        const p1jbFilter = transformedFilters.find((f) => f.startsWith('bj'));
-        const p2jbFilter = transformedFilters.find((f) => f.startsWith('BJ'));
-        const matchIDToken = transformedFilters.find((f) => f.startsWith('ma'));
-        const matchIDs = matchIDToken ? matchIDToken.slice(2) : '';
-        const tournamentIDToken = transformedFilters.find((f) => f.startsWith('tn'));
-        const tournamentIDs = tournamentIDToken ? tournamentIDToken.slice(2) : '';
-        const dtFilter = transformedFilters.includes('d');
-        const drFilter = transformedFilters.includes('D') || transformedFilters.includes('D1');
-        const drMode = transformedFilters.includes('D1') ? 'first' : 'both';
-        const cdFilter = transformedFilters.find((f) => f.startsWith('T'));
+        const {
+            incCube,
+            incScore,
+            ncFilter,
+            mirFilter,
+            pcFilter,
+            wrFilter,
+            grFilter,
+            bgFilter,
+            p2wrFilter,
+            p2grFilter,
+            p2bgFilter,
+            p1coFilter,
+            p2coFilter,
+            p1bcFilter,
+            p2bcFilter,
+            p1czFilter,
+            p2czFilter,
+            p1apcFilter,
+            eqFilter,
+            meFilter,
+            p1obFilter,
+            p2obFilter,
+            p1jbFilter,
+            p2jbFilter,
+            matchIDs,
+            tournamentIDs,
+            dtFilter,
+            drFilter,
+            drMode,
+            cdFilter
+        } = parseFilterTokens(transformedFilters);
 
         const searchCommand = buildSearchCommand(excludeActive ? [...transformedFilters, 'x'] : transformedFilters);
 

--- a/frontend/src/services/searchFilterService.js
+++ b/frontend/src/services/searchFilterService.js
@@ -276,3 +276,59 @@ export function buildSearchCommand(tokens) {
     });
     return commandParts.join(' ');
 }
+
+/**
+ * Pick the individual backend filter arguments back out of a token list.
+ *
+ * `onLoadPositionsByFilters` (in App.svelte) takes ~30 positional filter
+ * arguments, each of which SearchPanel derived from the `buildFilterTokens`
+ * output by prefix-matching the token array. That dense block of `find`/
+ * `includes` calls is pure (it depends only on the tokens), so it lives here
+ * where it can be unit-tested rather than inline in the component. Prefix
+ * collisions are disambiguated exactly as the original inline code did:
+ *   - `b…` is the player-1 backgammon-rate token, but NOT the outfield-blot
+ *     (`bo…`) or jan-blot (`bj…`) tokens; likewise `B…` vs `BO…`/`BJ…`.
+ *   - the double token may be `D` (both rolls) or `D1` (first roll only),
+ *     which also selects `drMode`.
+ * Match/tournament id tokens (`ma…`, `tn…`) are returned with their 2-char
+ * prefix stripped, as the backend expects.
+ *
+ * @param {string[]} tokens - the output of {@link buildFilterTokens}.
+ * @returns {object} the named filter arguments consumed by onLoadPositionsByFilters.
+ */
+export function parseFilterTokens(tokens) {
+    const matchIDToken = tokens.find((f) => f.startsWith('ma'));
+    const tournamentIDToken = tokens.find((f) => f.startsWith('tn'));
+    return {
+        incCube: tokens.includes('cube'),
+        incScore: tokens.includes('score'),
+        ncFilter: tokens.includes('nc'),
+        mirFilter: tokens.includes('M'),
+        pcFilter: tokens.find((f) => f.startsWith('p')),
+        wrFilter: tokens.find((f) => f.startsWith('w')),
+        grFilter: tokens.find((f) => f.startsWith('g')),
+        bgFilter: tokens.find((f) => f.startsWith('b') && !f.startsWith('bo') && !f.startsWith('bj')),
+        p2wrFilter: tokens.find((f) => f.startsWith('W')),
+        p2grFilter: tokens.find((f) => f.startsWith('G')),
+        p2bgFilter: tokens.find((f) => f.startsWith('B') && !f.startsWith('BO') && !f.startsWith('BJ')),
+        p1coFilter: tokens.find((f) => f.startsWith('o')),
+        p2coFilter: tokens.find((f) => f.startsWith('O')),
+        p1bcFilter: tokens.find((f) => f.startsWith('k')),
+        p2bcFilter: tokens.find((f) => f.startsWith('K')),
+        p1czFilter: tokens.find((f) => f.startsWith('z')),
+        p2czFilter: tokens.find((f) => f.startsWith('Z')),
+        p1apcFilter: tokens.find((f) => f.startsWith('P')),
+        eqFilter: tokens.find((f) => f.startsWith('e')),
+        meFilter: tokens.find((f) => f.startsWith('E')),
+        p1obFilter: tokens.find((f) => f.startsWith('bo')),
+        p2obFilter: tokens.find((f) => f.startsWith('BO')),
+        p1jbFilter: tokens.find((f) => f.startsWith('bj')),
+        p2jbFilter: tokens.find((f) => f.startsWith('BJ')),
+        matchIDs: matchIDToken ? matchIDToken.slice(2) : '',
+        tournamentIDs: tournamentIDToken ? tournamentIDToken.slice(2) : '',
+        dtFilter: tokens.includes('d'),
+        drFilter: tokens.includes('D') || tokens.includes('D1'),
+        drMode: tokens.includes('D1') ? 'first' : 'both',
+        cdFilter: tokens.find((f) => f.startsWith('T'))
+    };
+}


### PR DESCRIPTION
## Why

`SearchPanel.handleSearch` held ~32 lines of dense prefix-matching that derive the ~30 positional filter arguments for `onLoadPositionsByFilters` back out of the `buildFilterTokens` output. That block is **pure** (depends only on the token array) yet lived untested inside a 2630-line component — the first safe, verifiable slice of the SearchPanel decomposition.

## What

- Add `parseFilterTokens(tokens)` to `searchFilterService.js` (next to `buildFilterTokens`/`buildSearchCommand`), returning the named filter args.
- Replace the inline block in `handleSearch` with a destructuring call — **behaviour-preserving**: identical expressions, same prefix-collision handling (`b`/`bo`/`bj`, `B`/`BO`/`BJ`, `p`/`P`, `D`/`D1`).
- Add **7 unit tests** pinning the tricky disambiguations + a `buildFilterTokens` round-trip.

Full frontend suite green: **482 tests** (was 475).

## Scope note

The larger data-driven restructuring of the 700-line filter template is **deferred**: SearchPanel has zero component-level test coverage and restructuring it needs GUI verification this repo's headless test setup can't provide. This extraction is the safe, test-backed first step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)