### PR TITLE
feat(search): `blunders` / `bl` command to review your worst mistakes

### DIFF
--- a/doc/source/cmd_mode.rst
+++ b/doc/source/cmd_mode.rst
@@ -62,6 +62,7 @@ Positions et navigation
    "collection, coll", "Afficher/cacher le panneau des collections."
    "#tag1 tag2 ...", "Etiqueter la position courante."
    "e", "Charger toutes les positions de la base de données."
+   "blunders, bl", "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le filtre courant des statistiques."
    "m", "Naviguer dans le dernier match visité."
 
 

--- a/doc/source/locale/de/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/de/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -31,7 +31,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "Die Kommandozeile in der Statusleiste öffnet sich durch Drücken der *LEERTASTE*. Während der Eingabe eines Befehls erscheint automatisch eine Liste mit Vorschlägen: Die *TAB*-Taste (oder *UMSCHALT-TAB*) durchläuft die Vorschläge und vervollständigt den Befehl, während *ESC* die Liste schließt (ein zweites *ESC* schließt die Kommandozeile). Die Tasten *AUF* und *AB* bleiben dem Befehlsverlauf vorbehalten."
+msgstr ""
+"Die Kommandozeile in der Statusleiste öffnet sich durch Drücken der "
+"*LEERTASTE*. Während der Eingabe eines Befehls erscheint automatisch eine"
+" Liste mit Vorschlägen: Die *TAB*-Taste (oder *UMSCHALT-TAB*) durchläuft "
+"die Vorschläge und vervollständigt den Befehl, während *ESC* die Liste "
+"schließt (ein zweites *ESC* schließt die Kommandozeile). Die Tasten *AUF*"
+" und *AB* bleiben dem Befehlsverlauf vorbehalten."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -109,7 +115,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Lädt eine Beispieldatenbank (Matches, Turnier, Analysen), um das Werkzeug zu erkunden."
+msgstr ""
+"Lädt eine Beispieldatenbank (Matches, Turnier, Analysen), um das Werkzeug"
+" zu erkunden."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -304,6 +312,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Lädt alle Positionen aus der Datenbank."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Lädt die größten Fehler (Equity/MWC) in die Analyseansicht, gemäß dem aktuellen Statistikfilter."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -311,7 +329,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Navigiert zum zuletzt besuchten Match."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Bearbeitung und Suche"
 
@@ -347,11 +365,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Sucht unter den aktuell gefilterten Positionen."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Suchfilter"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -359,7 +377,7 @@ msgstr ""
 "Die folgenden Filter müssen bei einer Suche aneinandergereiht werden, das"
 " heißt nach dem Befehlsbeginn ``s``."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -372,7 +390,7 @@ msgstr ""
 "und die Würfel zu berücksichtigen, muss dies in der Suche ausdrücklich "
 "angegeben werden."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -382,7 +400,7 @@ msgstr ""
 "Befehl ``ss`` kann unter den aktuell gefilterten Ergebnissen gesucht "
 "werden."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -390,7 +408,7 @@ msgstr ""
 "blunderDB betrachtet einen rückständigen Stein (Backchecker) als einen "
 "Stein, der sich zwischen Punkt 24 und Punkt 19 befindet."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -398,7 +416,7 @@ msgstr ""
 "blunderDB betrachtet die Anzahl der Steine in der Zone als die Anzahl der"
 " Steine, die sich zwischen Punkt 12 und Punkt 1 befinden."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
@@ -406,13 +424,13 @@ msgstr ""
 "blunderDB betrachtet das Outfield als den Bereich zwischen Punkt 18 und "
 "Punkt 7."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr ""
 "blunderDB betrachtet das Heimfeld als den Bereich zwischen Punkt 1 und "
 "Punkt 6."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1092,7 +1110,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Die Positionen mit den Kennungen x bis y suchen (z. B. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1106,7 +1124,7 @@ msgstr ""
 "ersten Würfels wird verwendet, um Positionen zuzuordnen (auf einem der "
 "beiden Würfel des Wurfs)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1120,15 +1138,19 @@ msgstr ""
 "mindestens 10 Pips in Führung. `p50,70`: Der Spieler liegt im Rennen "
 "zwischen 50 und 70 Pips zurück."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "Um in mehreren nicht zusammenhängenden Matches zu suchen, wird der Filter ``ma`` mehrfach aneinandergereiht (z. B. ``s ma23 ma43`` für die Matches 23 und 43). Dasselbe Prinzip gilt für Turniere mit ``tn`` und für Positionen mit ``id`` (z. B. ``s id5 id10`` für die Positionen 5 und 10)."
+msgstr ""
+"Um in mehreren nicht zusammenhängenden Matches zu suchen, wird der Filter"
+" ``ma`` mehrfach aneinandergereiht (z. B. ``s ma23 ma43`` für die Matches"
+" 23 und 43). Dasselbe Prinzip gilt für Turniere mit ``tn`` und für "
+"Positionen mit ``id`` (z. B. ``s id5 id10`` für die Positionen 5 und 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1138,7 +1160,7 @@ msgstr ""
 "Matches des betreffenden Turniers. Die IDs der Matches und Turniere sind "
 "in den ID-Spalten der entsprechenden Panels sichtbar."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1154,7 +1176,7 @@ msgstr ""
 "Gewinnchancen, mindestens 10 Steinen in der Zone, und der Gegner zwischen"
 " 2 und 3 rückständige Steine hat."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Verschiedene Befehle"
 
@@ -1166,10 +1188,11 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Löscht den Befehlsverlauf."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr ""
 "Datenbankmigrationen werden jetzt beim Öffnen einer Datenbank automatisch"
 " durchgeführt."
+

--- a/doc/source/locale/el/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/el/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: el\n"
@@ -31,7 +31,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "Η γραμμή εντολών, που βρίσκεται στη γραμμή κατάστασης, ανοίγει πατώντας το πλήκτρο *ΔΙΑΣΤΗΜΑ*. Κατά την πληκτρολόγηση μιας εντολής, εμφανίζεται αυτόματα μια λίστα προτάσεων: το πλήκτρο *TAB* (ή *SHIFT-TAB*) διατρέχει τις προτάσεις και συμπληρώνει την εντολή, ενώ το *ESC* κλείνει τη λίστα (ένα δεύτερο *ESC* κλείνει τη γραμμή εντολών). Τα πλήκτρα *ΠΑΝΩ* και *ΚΑΤΩ* παραμένουν δεσμευμένα για το ιστορικό εντολών."
+msgstr ""
+"Η γραμμή εντολών, που βρίσκεται στη γραμμή κατάστασης, ανοίγει πατώντας "
+"το πλήκτρο *ΔΙΑΣΤΗΜΑ*. Κατά την πληκτρολόγηση μιας εντολής, εμφανίζεται "
+"αυτόματα μια λίστα προτάσεων: το πλήκτρο *TAB* (ή *SHIFT-TAB*) διατρέχει "
+"τις προτάσεις και συμπληρώνει την εντολή, ενώ το *ESC* κλείνει τη λίστα "
+"(ένα δεύτερο *ESC* κλείνει τη γραμμή εντολών). Τα πλήκτρα *ΠΑΝΩ* και "
+"*ΚΑΤΩ* παραμένουν δεσμευμένα για το ιστορικό εντολών."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -109,7 +115,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Φορτώνει μια βάση δείγματος (αγώνες, τουρνουά, αναλύσεις) για την εξερεύνηση του εργαλείου."
+msgstr ""
+"Φορτώνει μια βάση δείγματος (αγώνες, τουρνουά, αναλύσεις) για την "
+"εξερεύνηση του εργαλείου."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -304,6 +312,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Φορτώνει όλες τις θέσεις από τη βάση δεδομένων."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Φορτώνει τα χειρότερα λάθη (equity/MWC) στην προβολή ανάλυσης, σύμφωνα με το τρέχον φίλτρο στατιστικών."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -311,7 +329,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Πλοήγηση στον τελευταίο αγώνα που επισκεφθήκατε."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Επεξεργασία και αναζήτηση"
 
@@ -347,11 +365,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Αναζήτηση μεταξύ των θέσεων που είναι ήδη φιλτραρισμένες."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Φίλτρα αναζήτησης"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -359,7 +377,7 @@ msgstr ""
 "Τα παρακάτω φίλτρα πρέπει να τοποθετούνται διαδοχικά κατά τη διάρκεια "
 "μιας αναζήτησης, δηλαδή μετά την αρχή της εντολής ``s``."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -371,7 +389,7 @@ msgstr ""
 "ζάρια. Για να ληφθούν υπόψη η θέση του κύβου, το σκορ και τα ζάρια, "
 "πρέπει να αναφερθούν ρητά στην αναζήτηση."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -381,7 +399,7 @@ msgstr ""
 "``TAB``). Η εντολή ``ss`` επιτρέπει την αναζήτηση μεταξύ των "
 "αποτελεσμάτων που είναι ήδη φιλτραρισμένα."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -389,7 +407,7 @@ msgstr ""
 "Το blunderDB θεωρεί ότι ένα οπίσθιο πούλι (backchecker) είναι ένα πούλι "
 "που βρίσκεται μεταξύ του σημείου 24 και του σημείου 19."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -397,7 +415,7 @@ msgstr ""
 "Το blunderDB θεωρεί ότι ο αριθμός των πουλιών στη ζώνη είναι ο αριθμός "
 "των πουλιών που βρίσκονται μεταξύ του σημείου 12 και του σημείου 1."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
@@ -405,13 +423,13 @@ msgstr ""
 "Το blunderDB θεωρεί ότι το outfield εκτείνεται μεταξύ του σημείου 18 και "
 "του σημείου 7."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr ""
 "Το blunderDB θεωρεί ότι το jan εκτείνεται μεταξύ του σημείου 1 και του "
 "σημείου 6."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1087,7 +1105,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Αναζήτηση των θέσεων με αναγνωριστικά από x έως y (π.χ. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1101,7 +1119,7 @@ msgstr ""
 "ζαριού χρησιμοποιείται για την αντιστοίχιση των θέσεων (σε οποιοδήποτε "
 "από τα δύο ζάρια της ζαριάς)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1115,15 +1133,19 @@ msgstr ""
 "pips μπροστά στην κούρσα. `p50,70` : ο παίκτης είναι μεταξύ 50 και 70 "
 "pips πίσω στην κούρσα."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "Για αναζήτηση σε πολλούς μη συνεχόμενους αγώνες, επαναλάβετε το φίλτρο ``ma`` πολλές φορές (π.χ. ``s ma23 ma43`` για τους αγώνες 23 και 43). Η ίδια αρχή ισχύει για τα τουρνουά με ``tn`` και για τις θέσεις με ``id`` (π.χ. ``s id5 id10`` για τις θέσεις 5 και 10)."
+msgstr ""
+"Για αναζήτηση σε πολλούς μη συνεχόμενους αγώνες, επαναλάβετε το φίλτρο "
+"``ma`` πολλές φορές (π.χ. ``s ma23 ma43`` για τους αγώνες 23 και 43). Η "
+"ίδια αρχή ισχύει για τα τουρνουά με ``tn`` και για τις θέσεις με ``id`` "
+"(π.χ. ``s id5 id10`` για τις θέσεις 5 και 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1133,7 +1155,7 @@ msgstr ""
 "τους αγώνες του εν λόγω τουρνουά. Τα αναγνωριστικά των αγώνων και των "
 "τουρνουά είναι ορατά στις στήλες ID των αντίστοιχων πάνελ."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1149,7 +1171,7 @@ msgstr ""
 "τουλάχιστον 10 πούλια στη ζώνη, και ο αντίπαλος έχει μεταξύ 2 και 3 "
 "οπίσθια πούλια."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Διάφορες εντολές"
 
@@ -1161,10 +1183,11 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Διαγράφει το ιστορικό εντολών."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr ""
 "Οι μεταβάσεις της βάσης δεδομένων πραγματοποιούνται πλέον αυτόματα κατά "
 "το άνοιγμα μιας βάσης δεδομένων."
+

--- a/doc/source/locale/en/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/en/LC_MESSAGES/cmd_mode.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: 2025-02-06 00:12+0100\n"
 "Last-Translator: unger <kevin.unger@proton.me>\n"
 "Language: en\n"
@@ -30,7 +30,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "The command line, located in the status bar, opens by pressing the *SPACE* key. As you type a command, a list of suggestions appears automatically: the *TAB* key (or *SHIFT-TAB*) cycles through the suggestions and completes the command, while *ESC* closes the list (a second *ESC* closes the command line). The *UP* and *DOWN* keys remain reserved for the command history."
+msgstr ""
+"The command line, located in the status bar, opens by pressing the "
+"*SPACE* key. As you type a command, a list of suggestions appears "
+"automatically: the *TAB* key (or *SHIFT-TAB*) cycles through the "
+"suggestions and completes the command, while *ESC* closes the list (a "
+"second *ESC* closes the command line). The *UP* and *DOWN* keys remain "
+"reserved for the command history."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -108,7 +114,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Loads a sample database (matches, tournament, analyses) to explore the tool."
+msgstr ""
+"Loads a sample database (matches, tournament, analyses) to explore the "
+"tool."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -303,6 +311,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Load all positions from the database."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Load the worst mistakes (equity/MWC) into the analysis view, according to the current statistics filter."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -310,7 +328,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Navigate to the last visited match."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Editing and search"
 
@@ -346,11 +364,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Search among the currently filtered positions."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Search Filters"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -358,7 +376,7 @@ msgstr ""
 "The filters below must be juxtaposed during a search, i.e., after the "
 "start of the ``s`` command."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -370,7 +388,7 @@ msgstr ""
 "and the dice. To consider the position of the cube, the score, and the "
 "dice, it must be explicitly mentioned in the search."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -379,7 +397,7 @@ msgstr ""
 "The search command ``s`` is available in the search panel (``TAB`` key). "
 "The ``ss`` command allows searching among the currently filtered results."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -387,7 +405,7 @@ msgstr ""
 "blunderDB considers that a backchecker is a checker located between point"
 " 24 and point 19."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -395,17 +413,17 @@ msgstr ""
 "blunderDB considers that the number of checkers in the zone is the number"
 " of checkers located between point 12 and point 1."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
 msgstr "blunderDB considers the outfield to extend between point 18 and point 7."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr "blunderDB considers the jan to extend between point 1 and point 6."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1077,7 +1095,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Search for the positions with identifiers x to y (e.g. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1090,7 +1108,7 @@ msgstr ""
 " filter ignores the second die: only the first die's value is used to "
 "match positions (against either die of the roll)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1104,15 +1122,19 @@ msgstr ""
 "ahead in the race. `p50,70`: the player is between 50 and 70 pips behind "
 "in the race."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "To search across several non-contiguous matches, repeat the ``ma`` filter (e.g. ``s ma23 ma43`` for matches 23 and 43). The same principle applies to tournaments with ``tn`` and to positions with ``id`` (e.g. ``s id5 id10`` for positions 5 and 10)."
+msgstr ""
+"To search across several non-contiguous matches, repeat the ``ma`` filter"
+" (e.g. ``s ma23 ma43`` for matches 23 and 43). The same principle applies"
+" to tournaments with ``tn`` and to positions with ``id`` (e.g. ``s id5 "
+"id10`` for positions 5 and 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1122,7 +1144,7 @@ msgstr ""
 "that tournament. Match and tournament IDs are visible in the ID columns "
 "of the corresponding panels."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1137,7 +1159,7 @@ msgstr ""
 "ahead in the race, with at least 60% winning chances, at least 10 "
 "checkers in the zone, and the opponent has between 2 and 3 backcheckers."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Various commands"
 
@@ -1149,7 +1171,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Clear the command history."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
@@ -1540,3 +1562,4 @@ msgstr ""
 
 #~ msgid "Mode EDIT"
 #~ msgstr "EDIT Mode"
+

--- a/doc/source/locale/es/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/es/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -31,7 +31,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "La línea de comandos, situada en la barra de estado, se abre pulsando la tecla *ESPACIO*. Al escribir un comando, aparece automáticamente una lista de sugerencias: la tecla *TAB* (o *MAYÚS-TAB*) recorre las propuestas y completa el comando, mientras que *ESC* cierra la lista (un segundo *ESC* cierra la línea de comandos). Las teclas *ARRIBA* y *ABAJO* siguen reservadas al historial de comandos."
+msgstr ""
+"La línea de comandos, situada en la barra de estado, se abre pulsando la "
+"tecla *ESPACIO*. Al escribir un comando, aparece automáticamente una "
+"lista de sugerencias: la tecla *TAB* (o *MAYÚS-TAB*) recorre las "
+"propuestas y completa el comando, mientras que *ESC* cierra la lista (un "
+"segundo *ESC* cierra la línea de comandos). Las teclas *ARRIBA* y *ABAJO*"
+" siguen reservadas al historial de comandos."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -109,7 +115,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Carga una base de ejemplo (partidas, torneo, análisis) para descubrir la herramienta."
+msgstr ""
+"Carga una base de ejemplo (partidas, torneo, análisis) para descubrir la "
+"herramienta."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -304,6 +312,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Cargar todas las posiciones de la base de datos."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Carga los peores errores (equity/MWC) en la vista de análisis, según el filtro de estadísticas actual."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -311,7 +329,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Navegar por el último match visitado."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Edición y búsqueda"
 
@@ -347,11 +365,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Buscar entre las posiciones actualmente filtradas."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Filtros de búsqueda"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -359,7 +377,7 @@ msgstr ""
 "Los filtros siguientes deben yuxtaponerse durante una búsqueda, es decir,"
 " después del inicio del comando ``s``."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -371,7 +389,7 @@ msgstr ""
 "los dados. Para tener en cuenta la posición del cubo, el marcador y los "
 "dados, hay que mencionarlo explícitamente en la búsqueda."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -381,7 +399,7 @@ msgstr ""
 "(tecla ``TAB``). El comando ``ss`` permite buscar entre los resultados "
 "actualmente filtrados."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -389,7 +407,7 @@ msgstr ""
 "blunderDB considera que una ficha rezagada (backchecker) es una ficha "
 "situada entre el punto 24 y el punto 19."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -397,7 +415,7 @@ msgstr ""
 "blunderDB considera que el número de fichas en la zona es el número de "
 "fichas situadas entre el punto 12 y el punto 1."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
@@ -405,11 +423,11 @@ msgstr ""
 "blunderDB considera que el outfield se extiende entre el punto 18 y el "
 "punto 7."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr "blunderDB considera que el jan se extiende entre el punto 1 y el punto 6."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1088,7 +1106,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Buscar las posiciones con identificadores de x a y (p. ej. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1102,7 +1120,7 @@ msgstr ""
 "del primer dado para emparejar las posiciones (sobre cualquiera de los "
 "dos dados de la tirada)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1116,15 +1134,19 @@ msgstr ""
 "menos 10 pips de ventaja en la carrera. `p50,70` : el jugador tiene entre"
 " 50 y 70 pips de desventaja en la carrera."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "Para buscar en varias partidas no contiguas, repetir el filtro ``ma`` varias veces (p. ej. ``s ma23 ma43`` para las partidas 23 y 43). El mismo principio se aplica a los torneos con ``tn`` y a las posiciones con ``id`` (p. ej. ``s id5 id10`` para las posiciones 5 y 10)."
+msgstr ""
+"Para buscar en varias partidas no contiguas, repetir el filtro ``ma`` "
+"varias veces (p. ej. ``s ma23 ma43`` para las partidas 23 y 43). El mismo"
+" principio se aplica a los torneos con ``tn`` y a las posiciones con "
+"``id`` (p. ej. ``s id5 id10`` para las posiciones 5 y 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1134,7 +1156,7 @@ msgstr ""
 "matches de dicho torneo. Los identificadores de los matches y de los "
 "torneos son visibles en las columnas ID de los paneles correspondientes."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1150,7 +1172,7 @@ msgstr ""
 " al menos 10 fichas en la zona, y el adversario tiene entre 2 y 3 fichas "
 "rezagadas."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Comandos diversos"
 
@@ -1162,10 +1184,11 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Borra el historial de comandos."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr ""
 "Las migraciones de la base de datos se realizan ahora automáticamente al "
 "abrir una base de datos."
+

--- a/doc/source/locale/fi/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/fi/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fi\n"
@@ -31,7 +31,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "Komentorivi, joka sijaitsee tilarivillä, avataan painamalla *VÄLILYÖNTI*-näppäintä. Komentoa kirjoitettaessa ehdotusluettelo ilmestyy automaattisesti: *TAB*-näppäin (tai *VAIHTO-TAB*) selaa ehdotuksia ja täydentää komennon, kun taas *ESC* sulkee luettelon (toinen *ESC* sulkee komentorivin). *YLÖS*- ja *ALAS*-näppäimet on edelleen varattu komentohistorialle."
+msgstr ""
+"Komentorivi, joka sijaitsee tilarivillä, avataan painamalla "
+"*VÄLILYÖNTI*-näppäintä. Komentoa kirjoitettaessa ehdotusluettelo ilmestyy"
+" automaattisesti: *TAB*-näppäin (tai *VAIHTO-TAB*) selaa ehdotuksia ja "
+"täydentää komennon, kun taas *ESC* sulkee luettelon (toinen *ESC* sulkee "
+"komentorivin). *YLÖS*- ja *ALAS*-näppäimet on edelleen varattu "
+"komentohistorialle."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -109,7 +115,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Lataa esimerkkitietokannan (otteluita, turnaus, analyysejä) työkaluun tutustumista varten."
+msgstr ""
+"Lataa esimerkkitietokannan (otteluita, turnaus, analyysejä) työkaluun "
+"tutustumista varten."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -304,6 +312,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Lataa kaikki tietokannan asemat."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Lataa pahimmat virheet (equity/MWC) analyysinäkymään nykyisen tilastosuodattimen mukaisesti."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -311,7 +329,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Navigoi viimeksi käytyyn otteluun."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Muokkaus ja haku"
 
@@ -347,11 +365,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Etsi tällä hetkellä suodatettujen asemien joukosta."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Hakusuodattimet"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -359,7 +377,7 @@ msgstr ""
 "Alla olevat suodattimet on asetettava peräkkäin haun aikana, eli komennon"
 " ``s`` aloituksen jälkeen."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -371,7 +389,7 @@ msgstr ""
 "nopat. Jotta kuution asema, pistetilanne ja nopat otetaan huomioon, ne on"
 " mainittava nimenomaisesti haussa."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -381,7 +399,7 @@ msgstr ""
 "Komennon ``ss`` avulla voi etsiä tällä hetkellä suodatettujen tulosten "
 "joukosta."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -389,7 +407,7 @@ msgstr ""
 "blunderDB pitää takanappulana (backchecker) nappulaa, joka sijaitsee "
 "pisteiden 24 ja 19 välissä."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -397,17 +415,17 @@ msgstr ""
 "blunderDB pitää vyöhykkeen (zone) nappuloiden määränä niiden nappuloiden "
 "määrää, jotka sijaitsevat pisteiden 12 ja 1 välissä."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
 msgstr "blunderDB pitää ulkokentän (outfield) ulottuvan pisteiden 18 ja 7 välillä."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr "blunderDB pitää kotialueen (jan) ulottuvan pisteiden 1 ja 6 välillä."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1075,7 +1093,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Hae asemia, joiden tunnukset ovat välillä x–y (esim. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1089,7 +1107,7 @@ msgstr ""
 "ensimmäisen nopan arvoa käytetään asemien täsmäykseen (jommankumman "
 "heiton nopan kanssa)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1103,15 +1121,19 @@ msgstr ""
 "vähintään 10 pippiä edellä. `p50,70` : pelaaja on kilpajuoksussa 50–70 "
 "pippiä jäljessä."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "Useista ei-peräkkäisistä otteluista hakeaksesi toista suodatin ``ma`` useita kertoja (esim. ``s ma23 ma43`` otteluille 23 ja 43). Sama periaate pätee turnauksiin suodattimella ``tn`` ja asemiin suodattimella ``id`` (esim. ``s id5 id10`` asemille 5 ja 10)."
+msgstr ""
+"Useista ei-peräkkäisistä otteluista hakeaksesi toista suodatin ``ma`` "
+"useita kertoja (esim. ``s ma23 ma43`` otteluille 23 ja 43). Sama periaate"
+" pätee turnauksiin suodattimella ``tn`` ja asemiin suodattimella ``id`` "
+"(esim. ``s id5 id10`` asemille 5 ja 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1121,7 +1143,7 @@ msgstr ""
 "kaikista otteluista. Otteluiden ja turnausten tunnukset näkyvät "
 "vastaavien paneelien ID-sarakkeissa."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1136,7 +1158,7 @@ msgstr ""
 "vyöhykkeellä on vähintään 10 nappulaa, vastustajalla on 2–3 takanappulaa "
 "ja voittomahdollisuudet ovat vähintään 60%."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Sekalaisia komentoja"
 
@@ -1148,10 +1170,11 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Tyhjentää komentohistorian."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr ""
 "Tietokantojen migraatiot suoritetaan nyt automaattisesti tietokantaa "
 "avattaessa."
+

--- a/doc/source/locale/fr/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/fr/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blunderDB \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -302,6 +302,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr ""
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr ""
 
@@ -309,7 +319,7 @@ msgstr ""
 msgid "Naviguer dans le dernier match visité."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr ""
 
@@ -345,17 +355,17 @@ msgstr ""
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr ""
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -363,36 +373,36 @@ msgid ""
 " il faut le mentionner explicitement dans la recherche."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
 "les résultats actuellement filtrés."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1056,7 +1066,7 @@ msgstr ""
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1065,7 +1075,7 @@ msgid ""
 "l'autre des deux dés du lancer)."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1074,7 +1084,7 @@ msgid ""
 "retard à la course."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1082,14 +1092,14 @@ msgid ""
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
 "tournois sont visibles dans les colonnes ID des panneaux correspondants."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1099,7 +1109,7 @@ msgid ""
 "la zone, et l'adversaire a entre 2 et 3 pions arriérés."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr ""
 
@@ -1111,7 +1121,7 @@ msgstr ""
 msgid "Efface l'historique des commandes."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/it/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/it/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it\n"
@@ -31,7 +31,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "La riga di comando, situata nella barra di stato, si apre premendo il tasto *SPAZIO*. Durante la digitazione di un comando, appare automaticamente un elenco di suggerimenti: il tasto *TAB* (o *MAIUSC-TAB*) scorre le proposte e completa il comando, mentre *ESC* chiude l'elenco (un secondo *ESC* chiude la riga di comando). I tasti *SU* e *GIÙ* restano riservati alla cronologia dei comandi."
+msgstr ""
+"La riga di comando, situata nella barra di stato, si apre premendo il "
+"tasto *SPAZIO*. Durante la digitazione di un comando, appare "
+"automaticamente un elenco di suggerimenti: il tasto *TAB* (o *MAIUSC-"
+"TAB*) scorre le proposte e completa il comando, mentre *ESC* chiude "
+"l'elenco (un secondo *ESC* chiude la riga di comando). I tasti *SU* e "
+"*GIÙ* restano riservati alla cronologia dei comandi."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -109,7 +115,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Carica un database di esempio (partite, torneo, analisi) per scoprire lo strumento."
+msgstr ""
+"Carica un database di esempio (partite, torneo, analisi) per scoprire lo "
+"strumento."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -302,6 +310,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Carica tutte le posizioni del database."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Carica gli errori peggiori (equity/MWC) nella vista di analisi, secondo il filtro statistico corrente."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -309,7 +327,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Naviga nell'ultima partita visitata."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Modifica e ricerca"
 
@@ -345,11 +363,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Cerca tra le posizioni attualmente filtrate."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Filtri di ricerca"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -357,7 +375,7 @@ msgstr ""
 "I filtri sottostanti devono essere giustapposti durante una ricerca, "
 "ovvero dopo l'inizio del comando ``s``."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -369,7 +387,7 @@ msgstr ""
 " il punteggio e i dadi. Per tenere conto della posizione del cubo, del "
 "punteggio e dei dadi, occorre indicarlo esplicitamente nella ricerca."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -379,7 +397,7 @@ msgstr ""
 "``TAB``). Il comando ``ss`` permette di cercare tra i risultati "
 "attualmente filtrati."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -387,7 +405,7 @@ msgstr ""
 "blunderDB considera che una pedina arretrata (backchecker) sia una pedina"
 " situata tra il punto 24 e il punto 19."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -395,7 +413,7 @@ msgstr ""
 "blunderDB considera che il numero di pedine nella zona sia il numero di "
 "pedine situate tra il punto 12 e il punto 1."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
@@ -403,11 +421,11 @@ msgstr ""
 "blunderDB considera che l'outfield si estenda tra il punto 18 e il punto "
 "7."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr "blunderDB considera che il jan si estenda tra il punto 1 e il punto 6."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1083,7 +1101,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Cercare le posizioni con identificativi da x a y (es. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1097,7 +1115,7 @@ msgstr ""
 "dado viene usato per far corrispondere le posizioni (su uno qualsiasi dei"
 " due dadi del lancio)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1111,15 +1129,19 @@ msgstr ""
 "pip di vantaggio nella corsa. `p50,70` : il giocatore ha tra 50 e 70 pip "
 "di svantaggio nella corsa."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "Per cercare in più partite non contigue, ripetere più volte il filtro ``ma`` (es. ``s ma23 ma43`` per le partite 23 e 43). Lo stesso principio si applica ai tornei con ``tn`` e alle posizioni con ``id`` (es. ``s id5 id10`` per le posizioni 5 e 10)."
+msgstr ""
+"Per cercare in più partite non contigue, ripetere più volte il filtro "
+"``ma`` (es. ``s ma23 ma43`` per le partite 23 e 43). Lo stesso principio "
+"si applica ai tornei con ``tn`` e alle posizioni con ``id`` (es. ``s id5 "
+"id10`` per le posizioni 5 e 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1129,7 +1151,7 @@ msgstr ""
 "torneo interessato. Gli identificatori delle partite e dei tornei sono "
 "visibili nelle colonne ID dei pannelli corrispondenti."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1145,7 +1167,7 @@ msgstr ""
 "almeno 10 pedine nella zona, e l'avversario ha tra 2 e 3 pedine "
 "arretrate."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Comandi vari"
 
@@ -1157,10 +1179,11 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Cancella la cronologia dei comandi."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr ""
 "Le migrazioni del database vengono ora eseguite automaticamente "
 "all'apertura di un database."
+

--- a/doc/source/locale/ja/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/ja/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
@@ -31,7 +31,10 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "コマンドラインはステータスバーにあり、 *スペース* キーを押すと開きます。コマンドを入力すると、候補のリストが自動的に表示されます。 *TAB* キー（または *Shift-TAB* ）は候補を順に巡回してコマンドを補完し、 *ESC* はリストを閉じます（2回目の *ESC* でコマンドラインが閉じます）。 *上* キーと *下* キーは引き続きコマンド履歴用に予約されています。"
+msgstr ""
+"コマンドラインはステータスバーにあり、 *スペース* キーを押すと開きます。コマンドを入力すると、候補のリストが自動的に表示されます。 *TAB*"
+" キー（または *Shift-TAB* ）は候補を順に巡回してコマンドを補完し、 *ESC* はリストを閉じます（2回目の *ESC* "
+"でコマンドラインが閉じます）。 *上* キーと *下* キーは引き続きコマンド履歴用に予約されています。"
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -302,6 +305,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "データベースのすべての局面を読み込みます。"
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "現在の統計フィルターに従って、最悪のミス（エクイティ/MWC）を分析ビューに読み込みます。"
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -309,7 +322,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "最後に閲覧したマッチ内を移動します。"
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "編集と検索"
 
@@ -345,17 +358,17 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "現在フィルタされている局面の中から検索します。"
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "検索フィルタ"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
 msgstr "以下のフィルタは検索時、すなわちコマンドの先頭 ``s`` の後に並べて指定する必要があります。"
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -365,7 +378,7 @@ msgstr ""
 "局面検索では、デフォルトで blunderDB "
 "は現在の駒の配置を考慮し、キューブ、スコア、ダイスの状態は無視します。キューブ、スコア、ダイスを考慮させるには、検索時に明示的に指定する必要があります。"
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -374,29 +387,29 @@ msgstr ""
 "検索コマンド ``s`` は検索パネル（``TAB`` キー）で利用できます。コマンド ``ss`` "
 "を使うと、現在フィルタされている結果の中から検索できます。"
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
 msgstr "blunderDB は、後方の駒（バックチェッカー）を 24 ポイントから 19 ポイントの間にある駒とみなします。"
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
 msgstr "blunderDB は、ゾーン内の駒数を 12 ポイントから 1 ポイントの間にある駒数とみなします。"
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
 msgstr "blunderDB は、アウトフィールドが 18 ポイントから 7 ポイントに及ぶとみなします。"
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr "blunderDB は、内盤（jan）が 1 ポイントから 6 ポイントに及ぶとみなします。"
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1060,7 +1073,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "識別子 x から y までのポジションを検索します（例: id5,10）。"
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1072,7 +1085,7 @@ msgstr ""
 " `D1` は 2 つ目のダイスの値を無視します。局面のマッチには 1 つ目のダイスの値のみが使われます（出目の 2 "
 "つのダイスのいずれかに対して）。"
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1084,15 +1097,18 @@ msgstr ""
 "のとき進んでいます。例: `p<-10` : プレイヤーがレースで少なくとも 10 ピップ進んでいます。`p50,70` : プレイヤーがレースで"
 " 50 から 70 ピップ遅れています。"
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "連続していない複数のマッチ内を検索するには、フィルタ ``ma`` を複数回並べて指定します（例: マッチ 23 と 43 の場合は ``s ma23 ma43`` ）。同じ原則がトーナメントの ``tn`` にも、ポジションの ``id`` にも適用されます（例: ポジション 5 と 10 の場合は ``s id5 id10`` ）。"
+msgstr ""
+"連続していない複数のマッチ内を検索するには、フィルタ ``ma`` を複数回並べて指定します（例: マッチ 23 と 43 の場合は ``s "
+"ma23 ma43`` ）。同じ原則がトーナメントの ``tn`` にも、ポジションの ``id`` にも適用されます（例: ポジション 5 と "
+"10 の場合は ``s id5 id10`` ）。"
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1101,7 +1117,7 @@ msgstr ""
 "トーナメント（``tn``）内を検索することは、該当トーナメントのすべてのマッチ内を検索することと同じです。マッチとトーナメントの識別子は、対応するパネルの"
 " ID 列で確認できます。"
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1114,7 +1130,7 @@ msgstr ""
 "は、編集中の局面の駒の配置、スコア、キューブを考慮し、プレイヤーがレースで 20 から 5 ピップ進んでおり、勝率が少なくとも "
 "60%、ゾーン内に少なくとも 10 個の駒があり、相手が 2 から 3 個の後方の駒を持つすべての局面をフィルタします。"
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "その他のコマンド"
 
@@ -1126,8 +1142,9 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "コマンド履歴を消去します。"
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr "データベースのマイグレーションは、データベースを開く際に自動的に実行されるようになりました。"
+

--- a/doc/source/locale/ru/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/ru/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-05 04:08+0200\n"
+"POT-Creation-Date: 2026-06-13 02:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -32,7 +32,13 @@ msgid ""
 "parcourt les propositions et complète la commande, tandis que *ÉCHAP* "
 "referme la liste (un second *ÉCHAP* ferme la ligne de commande). Les "
 "touches *HAUT* et *BAS* restent réservées à l'historique des commandes."
-msgstr "Командная строка, расположенная в строке состояния, открывается нажатием клавиши *ПРОБЕЛ*. При вводе команды автоматически появляется список подсказок: клавиша *TAB* (или *SHIFT-TAB*) перебирает предложения и дополняет команду, а *ESC* закрывает список (второе нажатие *ESC* закрывает командную строку). Клавиши *ВВЕРХ* и *ВНИЗ* остаются зарезервированными для истории команд."
+msgstr ""
+"Командная строка, расположенная в строке состояния, открывается нажатием "
+"клавиши *ПРОБЕЛ*. При вводе команды автоматически появляется список "
+"подсказок: клавиша *TAB* (или *SHIFT-TAB*) перебирает предложения и "
+"дополняет команду, а *ESC* закрывает список (второе нажатие *ESC* "
+"закрывает командную строку). Клавиши *ВВЕРХ* и *ВНИЗ* остаются "
+"зарезервированными для истории команд."
 
 #: ../../source/cmd_mode.rst:16
 msgid "Opérations globales"
@@ -110,7 +116,9 @@ msgstr "demo"
 msgid ""
 "Charge une base d'exemple (matchs, tournoi, analyses) pour découvrir "
 "l'outil."
-msgstr "Загружает образец базы данных (матчи, турнир, анализы) для знакомства с инструментом."
+msgstr ""
+"Загружает образец базы данных (матчи, турнир, анализы) для знакомства с "
+"инструментом."
 
 #: ../../source/cmd_mode.rst:1
 msgid "meta"
@@ -305,6 +313,16 @@ msgid "Charger toutes les positions de la base de données."
 msgstr "Загрузить все позиции базы данных."
 
 #: ../../source/cmd_mode.rst:1
+msgid "blunders, bl"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
+"filtre courant des statistiques."
+msgstr "Загружает худшие ошибки (equity/MWC) в представление анализа согласно текущему фильтру статистики."
+
+#: ../../source/cmd_mode.rst:1
 msgid "m"
 msgstr "m"
 
@@ -312,7 +330,7 @@ msgstr "m"
 msgid "Naviguer dans le dernier match visité."
 msgstr "Навигация по последнему просмотренному матчу."
 
-#: ../../source/cmd_mode.rst:71
+#: ../../source/cmd_mode.rst:72
 msgid "Édition et recherche"
 msgstr "Редактирование и поиск"
 
@@ -348,11 +366,11 @@ msgstr "ss"
 msgid "Chercher parmi les positions actuellement filtrées."
 msgstr "Искать среди текущих отфильтрованных позиций."
 
-#: ../../source/cmd_mode.rst:88
+#: ../../source/cmd_mode.rst:89
 msgid "Filtres de recherche"
 msgstr "Фильтры поиска"
 
-#: ../../source/cmd_mode.rst:90
+#: ../../source/cmd_mode.rst:91
 msgid ""
 "Les filtres ci-dessous doivent être juxtaposés lors d'une recherche, "
 "c'est-à-dire après le début de commande ``s``."
@@ -360,7 +378,7 @@ msgstr ""
 "Приведённые ниже фильтры должны указываться друг за другом при поиске, то"
 " есть после начала команды ``s``."
 
-#: ../../source/cmd_mode.rst:95
+#: ../../source/cmd_mode.rst:96
 msgid ""
 "Dans la recherche de positions, par défaut, blunderDB prend en compte la "
 "structure de pions courante, ignore la position du videau, du score et "
@@ -371,7 +389,7 @@ msgstr ""
 "шашек, игнорируя положение куба, счёт и кубики. Чтобы учитывать положение"
 " куба, счёт и кубики, это нужно явно указать в поиске."
 
-#: ../../source/cmd_mode.rst:101
+#: ../../source/cmd_mode.rst:102
 msgid ""
 "La commande de recherche ``s`` est disponible dans le panneau de "
 "recherche (touche ``TAB``). La commande ``ss`` permet de chercher parmi "
@@ -380,7 +398,7 @@ msgstr ""
 "Команда поиска ``s`` доступна на панели поиска (клавиша ``TAB``). Команда"
 " ``ss`` позволяет искать среди текущих отфильтрованных результатов."
 
-#: ../../source/cmd_mode.rst:106
+#: ../../source/cmd_mode.rst:107
 msgid ""
 "blunderDB considère qu'un pion arriéré (backchecker) est un pion situé "
 "entre le point 24 et le point 19."
@@ -388,7 +406,7 @@ msgstr ""
 "blunderDB считает, что задняя шашка (backchecker) — это шашка, "
 "расположенная между пунктом 24 и пунктом 19."
 
-#: ../../source/cmd_mode.rst:110
+#: ../../source/cmd_mode.rst:111
 msgid ""
 "blunderDB considère que le nombre de pions dans la zone est le nombre de "
 "pions situés entre le point 12 et le point 1."
@@ -396,17 +414,17 @@ msgstr ""
 "blunderDB считает, что число шашек в зоне — это число шашек, "
 "расположенных между пунктом 12 и пунктом 1."
 
-#: ../../source/cmd_mode.rst:114
+#: ../../source/cmd_mode.rst:115
 msgid ""
 "blunderDB considère que l'outfield s'étend entre le point 18 et le point "
 "7."
 msgstr "blunderDB считает, что аутфилд простирается между пунктом 18 и пунктом 7."
 
-#: ../../source/cmd_mode.rst:117
+#: ../../source/cmd_mode.rst:118
 msgid "blunderDB considère que le jan s'étend entre le point 1 et le point 6."
 msgstr "blunderDB считает, что ян простирается между пунктом 1 и пунктом 6."
 
-#: ../../source/cmd_mode.rst:120
+#: ../../source/cmd_mode.rst:121
 msgid ""
 "Les paramètres pour filtrer des positions peuvent être arbitrairement "
 "combinés."
@@ -1076,7 +1094,7 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Найти позиции с идентификаторами от x до y (напр. id5,10)."
 
-#: ../../source/cmd_mode.rst:210
+#: ../../source/cmd_mode.rst:211
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1089,7 +1107,7 @@ msgstr ""
 "игнорирует значение второго кубика: только значение первого кубика "
 "используется для сопоставления позиций (с любым из двух кубиков броска)."
 
-#: ../../source/cmd_mode.rst:216
+#: ../../source/cmd_mode.rst:217
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1102,15 +1120,19 @@ msgstr ""
 "Пример: `p<-10`: игрок опережает как минимум на 10 пипов. `p50,70`: игрок"
 " отстаёт на 50–70 пипов в гонке."
 
-#: ../../source/cmd_mode.rst:222
+#: ../../source/cmd_mode.rst:223
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
 "même principe s'applique pour les tournois avec ``tn`` et pour les "
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
-msgstr "Чтобы искать в нескольких несмежных матчах, повторите фильтр ``ma`` несколько раз (напр. ``s ma23 ma43`` для матчей 23 и 43). Тот же принцип применяется к турнирам с ``tn`` и к позициям с ``id`` (напр. ``s id5 id10`` для позиций 5 и 10)."
+msgstr ""
+"Чтобы искать в нескольких несмежных матчах, повторите фильтр ``ma`` "
+"несколько раз (напр. ``s ma23 ma43`` для матчей 23 и 43). Тот же принцип "
+"применяется к турнирам с ``tn`` и к позициям с ``id`` (напр. ``s id5 "
+"id10`` для позиций 5 и 10)."
 
-#: ../../source/cmd_mode.rst:227
+#: ../../source/cmd_mode.rst:228
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1120,7 +1142,7 @@ msgstr ""
 "Идентификаторы матчей и турниров видны в столбцах ID соответствующих "
 "панелей."
 
-#: ../../source/cmd_mode.rst:231
+#: ../../source/cmd_mode.rst:232
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1134,7 +1156,7 @@ msgstr ""
 "игрока от 20 до 5 пипов преимущества в гонке, вероятность победы не менее"
 " 60%, не менее 10 шашек в зоне, и у противника от 2 до 3 задних шашек."
 
-#: ../../source/cmd_mode.rst:241
+#: ../../source/cmd_mode.rst:242
 msgid "Commandes diverses"
 msgstr "Прочие команды"
 
@@ -1146,10 +1168,11 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Очищает историю команд."
 
-#: ../../source/cmd_mode.rst:250
+#: ../../source/cmd_mode.rst:251
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."
 msgstr ""
 "Миграция базы данных теперь выполняется автоматически при открытии базы "
 "данных."
+

--- a/frontend/src/App.svelte
+++ b/frontend/src/App.svelte
@@ -90,6 +90,7 @@
     import { saveSessionState } from './services/sessionService.js';
     import { handleKeyDown, toggleHelpModal, toggleSearchHistoryPanel } from './services/keyboardService.js';
     import { applyTabPanels } from './services/tabHandler.js';
+    import { loadWorstBlunders } from './services/positionLoader.js';
 
     // Components
     import Toolbar from './components/Toolbar.svelte';
@@ -357,7 +358,8 @@
             toggleCollectionPanel: toggleCollectionPanelAction,
             toggleEPCMode,
             toggleMatchMode,
-            onToggleStats: () => toggleStatsPanel()
+            onToggleStats: () => toggleStatsPanel(),
+            onLoadBlunders: loadWorstBlunders
         });
         window.addEventListener('keydown', handleKeyDown);
         mainArea.addEventListener('wheel', handleWheel);

--- a/frontend/src/__tests__/commandProcessor.test.js
+++ b/frontend/src/__tests__/commandProcessor.test.js
@@ -363,7 +363,8 @@ describe('processCommand', () => {
             toggleCollectionPanel: vi.fn(),
             toggleEPCMode: vi.fn(),
             toggleMatchMode: vi.fn(),
-            onToggleStats: vi.fn()
+            onToggleStats: vi.fn(),
+            onLoadBlunders: vi.fn()
         };
         initCommandProcessor(callbacks);
 
@@ -456,6 +457,8 @@ describe('processCommand', () => {
         ['coll', 'toggleCollectionPanel'],
         ['stats', 'onToggleStats'],
         ['st', 'onToggleStats'],
+        ['blunders', 'onLoadBlunders'],
+        ['bl', 'onLoadBlunders'],
         ['epc', 'toggleEPCMode'],
         ['m', 'toggleMatchMode']
     ];

--- a/frontend/src/__tests__/positionLoader.test.js
+++ b/frontend/src/__tests__/positionLoader.test.js
@@ -50,16 +50,27 @@ vi.mock('../stores/positionStore.js', () => {
     };
 });
 
+// Mock statsStore (real module imports Wails bindings); expose only the filter.
+vi.mock('../stores/statsStore.js', () => {
+    const { writable } = require('svelte/store');
+    return {
+        statsFilterStore: writable({ decisionType: -1, playerName: '', tournamentIDs: [], dateFrom: '', dateTo: '', matchLength: [] })
+    };
+});
+
 import { GetPositionIDsByStatsSelection, GetPositionIDsByTournament, GetPositionIDsByMatch, LoadPositionsByFilters } from '../../wailsjs/go/database/Database.js';
 
 import {
     loadPositionsFromSelection,
     loadPositionsFromStatsSelection,
+    loadWorstBlunders,
     loadPositionsFromTournament,
     loadPositionsFromMatch,
     openTournamentInPanel,
     openMatchInPanel
 } from '../services/positionLoader.js';
+
+import { statsFilterStore } from '../stores/statsStore.js';
 
 import { activeTabStore } from '../stores/uiStore.js';
 import { selectedTournamentStore } from '../stores/tournamentStore.js';
@@ -90,6 +101,27 @@ describe('loadPositionsFromStatsSelection', () => {
         await loadPositionsFromStatsSelection({}, { kind: 'all' });
 
         expect(get(positionsStore)).toEqual([{ id: 10 }, { id: 20 }]);
+        expect(get(activeTabStore)).toBe('analysis');
+    });
+});
+
+describe('loadWorstBlunders', () => {
+    beforeEach(() => {
+        vi.resetAllMocks();
+        positionsStore.set([]);
+        activeTabStore.set('something');
+    });
+
+    test('requests the top_blunders selection under the current stats filter', async () => {
+        const filter = { decisionType: 1, playerName: 'Alice', tournamentIDs: [], dateFrom: '', dateTo: '', matchLength: [] };
+        statsFilterStore.set(filter);
+        GetPositionIDsByStatsSelection.mockResolvedValue([7, 8]);
+        LoadPositionsByFilters.mockResolvedValue([{ id: 7 }, { id: 8 }]);
+
+        await loadWorstBlunders();
+
+        expect(GetPositionIDsByStatsSelection).toHaveBeenCalledWith(filter, { Kind: 'top_blunders' });
+        expect(get(positionsStore)).toEqual([{ id: 7 }, { id: 8 }]);
         expect(get(activeTabStore)).toBe('analysis');
     });
 });

--- a/frontend/src/commandProcessor.js
+++ b/frontend/src/commandProcessor.js
@@ -72,6 +72,8 @@ export function processCommand(command) {
         callbacks.onLoadAllPositions?.();
     } else if (command === 'stats' || command === 'st') {
         callbacks.onToggleStats?.();
+    } else if (command === 'blunders' || command === 'bl') {
+        callbacks.onLoadBlunders?.();
     } else if (command.startsWith('ss')) {
         handleSubSearch(command, positions);
     } else if (command.startsWith('s')) {

--- a/frontend/src/commandVocabulary.js
+++ b/frontend/src/commandVocabulary.js
@@ -26,6 +26,7 @@ export const COMMANDS = [
     { name: 's', aliases: [] },
     { name: 'ss', aliases: [] },
     { name: 'stats', aliases: ['st'] },
+    { name: 'blunders', aliases: ['bl'] },
     { name: 'filter', aliases: ['fl'] },
     { name: 'history', aliases: ['hi'] },
     { name: 'match', aliases: ['ma'] },

--- a/frontend/src/services/positionLoader.js
+++ b/frontend/src/services/positionLoader.js
@@ -22,6 +22,7 @@ import { positionsStore } from '../stores/positionStore.js';
 import { currentPositionIndexStore } from '../stores/uiStore.js';
 import { selectedTournamentStore } from '../stores/tournamentStore.js';
 import { databasePathStore } from '../stores/databaseStore.js';
+import { statsFilterStore } from '../stores/statsStore.js';
 
 /**
  * Push a list of position IDs into the analysis view.
@@ -66,6 +67,20 @@ export async function loadPositionsFromSelection(ids, { focusIndex = 0 } = {}) {
 export async function loadPositionsFromStatsSelection(filter, selection) {
     const ids = await GetPositionIDsByStatsSelection(filter, selection);
     return loadPositionsFromSelection(ids);
+}
+
+/**
+ * Load the worst blunders (the decisions with the largest equity/MWC error)
+ * into the analysis view, newest-mistake-first review made one keystroke away.
+ *
+ * Reuses the Stats panel's "top_blunders" selection (its top-10 by error
+ * magnitude) under the current stats filter — which defaults to all decisions,
+ * but honours any player/date/decision-type scope the user has set in the Stats
+ * panel. This is the `blunders`/`bl` command's backing action.
+ */
+export async function loadWorstBlunders() {
+    const filter = get(statsFilterStore);
+    return loadPositionsFromStatsSelection(filter, { Kind: 'top_blunders' });
 }
 
 /**


### PR DESCRIPTION
## Why

blunderDB *is* a blunder database, yet reaching your worst decisions meant opening the Stats panel → Errors tab → drilling into the histogram. This adds a one-keystroke path to the core use case.

## What

`blunders` (alias `bl`) loads the worst decisions — largest equity/MWC error — straight into the analysis view.

- **No new backend**: reuses the Stats panel's tested `top_blunders` selection via `positionLoader.loadWorstBlunders`, under the current stats filter (defaults to all decisions, but honours any player/date/decision-type scope set in Stats). `GetPositionIDsByStatsSelection` already backs it; `loadPositionsFromSelection` already handles the no-database / no-results cases.
- Wired through `commandProcessor` (`onLoadBlunders`) and registered in `commandVocabulary` for autocomplete.
- **Docs**: command reference (French source) + translated into the 8 target languages.

## Tests

- command dispatch: `blunders`/`bl` → `onLoadBlunders` (commandProcessor.test);
- `loadWorstBlunders` requests the `top_blunders` selection under the active filter and loads results into the analysis view (positionLoader.test).

Full frontend suite **485** (+3), lint + `vite build` clean; EN & JA doc builds render the command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)