### PR TITLE
feat(search): hover hint exposing each filter's command-line token

### DIFF
--- a/frontend/src/__tests__/searchFilterService.test.js
+++ b/frontend/src/__tests__/searchFilterService.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
-import { buildFilterTokens, buildSearchCommand, parseFilterTokens } from '../services/searchFilterService.js';
+import { buildFilterTokens, buildSearchCommand, parseFilterTokens, filterTokenHint } from '../services/searchFilterService.js';
 
 // buildFilterTokens/buildSearchCommand are pure (no Wails imports), but the
 // round-trip block below imports commandProcessor's parseFilters, which pulls in
@@ -342,5 +342,43 @@ describe('parseFilterTokens', () => {
         expect(p.eqFilter).toBe('e10,50');
         expect(p.meFilter).toBe('E>5');
         expect(p.p1coFilter).toBe('o>2');
+    });
+});
+
+describe('filterTokenHint', () => {
+    test('range filters show the three operator forms', () => {
+        expect(filterTokenHint('Player Back Checker')).toBe('k>n · k<n · kn,m');
+        expect(filterTokenHint('Equity (millipoints)')).toBe('e>n · e<n · en,m');
+        expect(filterTokenHint('Opponent Jan Blot')).toBe('BJ>n · BJ<n · BJn,m');
+    });
+
+    test('flag filters show the bare token', () => {
+        expect(filterTokenHint('No Contact')).toBe('nc');
+        expect(filterTokenHint('Include Cube')).toBe('cube');
+        expect(filterTokenHint('Mirror Position')).toBe('M');
+    });
+
+    test('dice, text and date filters show their special forms', () => {
+        expect(filterTokenHint('Include Dice Roll')).toBe('D · D1');
+        expect(filterTokenHint('Search Text')).toBe('t"…"');
+        expect(filterTokenHint('Creation Date')).toBe('T>YYYY/MM/DD · T<YYYY/MM/DD');
+    });
+
+    test('unknown labels return empty string (no tooltip)', () => {
+        expect(filterTokenHint('Not A Filter')).toBe('');
+        expect(filterTokenHint('')).toBe('');
+    });
+
+    test('every hint begins with its declared token', () => {
+        // Guards against a prefix/typo drift between the hint and buildFilterTokens.
+        const cases = [
+            ['Win Rate', 'w'],
+            ['Opponent Win Rate', 'W'],
+            ['Player Checker in the Zone', 'z'],
+            ['Player Outfield Blot', 'bo']
+        ];
+        for (const [label, tok] of cases) {
+            expect(filterTokenHint(label).startsWith(tok)).toBe(true);
+        }
     });
 });

--- a/frontend/src/components/SearchPanel.svelte
+++ b/frontend/src/components/SearchPanel.svelte
@@ -6,7 +6,7 @@
     import { positionStore, positionsStore, positionBeforeFilterLibraryStore, positionIndexBeforeFilterLibraryStore } from '../stores/positionStore';
     import { searchExcludePositionStore, searchStructureModeStore, searchOfferedCubeStore, emptySearchBoardPosition, boardHasCheckers } from '../stores/searchExcludePositionStore';
     import { searchHistoryStore } from '../stores/searchHistoryStore';
-    import { buildFilterTokens, buildSearchCommand, parseFilterTokens } from '../services/searchFilterService.js';
+    import { buildFilterTokens, buildSearchCommand, parseFilterTokens, filterTokenHint } from '../services/searchFilterService.js';
     import { filterLibraryStore } from '../stores/filterLibraryStore';
     import { searchParamsStore } from '../stores/searchParamsStore';
     import { databaseLoadedStore } from '../stores/databaseStore';
@@ -1325,8 +1325,10 @@
                                             bind:checked={filterEnabled[filter]}
                                             disabled={filter === 'Include Dice Roll' && filterEnabled['Include Decision Type'] && decisionMode === 'cube'}
                                         />
-                                        <span class="filter-label" class:label-disabled={filter === 'Include Dice Roll' && filterEnabled['Include Decision Type'] && decisionMode === 'cube'}
-                                            >{filterLabel(filter)}</span
+                                        <span
+                                            class="filter-label"
+                                            class:label-disabled={filter === 'Include Dice Roll' && filterEnabled['Include Decision Type'] && decisionMode === 'cube'}
+                                            title={filterTokenHint(filter)}>{filterLabel(filter)}</span
                                         >
                                     </label>
                                     {#if filterEnabled[filter]}

--- a/frontend/src/services/searchFilterService.js
+++ b/frontend/src/services/searchFilterService.js
@@ -332,3 +332,74 @@ export function parseFilterTokens(tokens) {
         cdFilter: tokens.find((f) => f.startsWith('T'))
     };
 }
+
+// Command-line token for each search filter, keyed by its canonical (English)
+// label — the same labels SearchPanel's filterGroups use. Single source of
+// truth for the in-UI token hint shown on hover; the prefixes mirror the
+// buildFilterTokens switch above. `type` drives how filterTokenHint renders the
+// usage forms:
+//   flag  — the bare token (cube, nc, M, d)
+//   range — three forms: X>n, X<n, Xn,m
+//   text  — quoted free text: t"…"
+//   date  — T>YYYY/MM/DD …
+//   dice  — D (both rolls) / D1 (first roll only)
+const FILTER_TOKENS = {
+    'Include Cube': { token: 'cube', type: 'flag' },
+    'Include Score': { token: 'score', type: 'flag' },
+    'Include Decision Type': { token: 'd', type: 'flag' },
+    'Include Dice Roll': { token: 'D', type: 'dice' },
+    'No Contact': { token: 'nc', type: 'flag' },
+    'Mirror Position': { token: 'M', type: 'flag' },
+    'Pipcount Difference': { token: 'p', type: 'range' },
+    'Player Absolute Pipcount': { token: 'P', type: 'range' },
+    'Equity (millipoints)': { token: 'e', type: 'range' },
+    'Move Error (millipoints, Player 1)': { token: 'E', type: 'range' },
+    'Win Rate': { token: 'w', type: 'range' },
+    'Gammon Rate': { token: 'g', type: 'range' },
+    'Backgammon Rate': { token: 'b', type: 'range' },
+    'Opponent Win Rate': { token: 'W', type: 'range' },
+    'Opponent Gammon Rate': { token: 'G', type: 'range' },
+    'Opponent Backgammon Rate': { token: 'B', type: 'range' },
+    'Player Checker-Off': { token: 'o', type: 'range' },
+    'Opponent Checker-Off': { token: 'O', type: 'range' },
+    'Player Back Checker': { token: 'k', type: 'range' },
+    'Opponent Back Checker': { token: 'K', type: 'range' },
+    'Player Checker in the Zone': { token: 'z', type: 'range' },
+    'Opponent Checker in the Zone': { token: 'Z', type: 'range' },
+    'Player Outfield Blot': { token: 'bo', type: 'range' },
+    'Opponent Outfield Blot': { token: 'BO', type: 'range' },
+    'Player Jan Blot': { token: 'bj', type: 'range' },
+    'Opponent Jan Blot': { token: 'BJ', type: 'range' },
+    'Search Text': { token: 't', type: 'text' },
+    'Best Move or Cube Decision': { token: 'm', type: 'text' },
+    'Creation Date': { token: 'T', type: 'date' }
+};
+
+/**
+ * The command-line token hint for a filter label, shown as the filter's `title`
+ * (hover tooltip) in SearchPanel so the cryptic `s` tokens are discoverable
+ * without leaving the UI. Returns '' for unknown labels. The string is
+ * deliberately word-free — only the token and its operator forms — so it needs
+ * no translation.
+ *
+ * @param {string} label - the canonical (English) filter label.
+ * @returns {string}
+ */
+export function filterTokenHint(label) {
+    const entry = FILTER_TOKENS[label];
+    if (!entry) return '';
+    const { token, type } = entry;
+    switch (type) {
+        case 'range':
+            return `${token}>n · ${token}<n · ${token}n,m`;
+        case 'text':
+            return `${token}"…"`;
+        case 'date':
+            return `${token}>YYYY/MM/DD · ${token}<YYYY/MM/DD`;
+        case 'dice':
+            return `${token} · ${token}1`;
+        case 'flag':
+        default:
+            return token;
+    }
+}


### PR DESCRIPTION
## Why

SearchPanel filters show a translated label but nothing connects, e.g. "Player Back Checker" to the `k` token you type on the `s` command line — the tokens were only discoverable in the manual.

## What

A `title` (hover) tooltip on each filter label showing its token and operator forms:
- ranges → `k>n · k<n · kn,m`
- flags → `nc`, `cube`, `M`
- text → `t"…"`, dice → `D · D1`, date → `T>YYYY/MM/DD · T<YYYY/MM/DD`

Single source of truth: `FILTER_TOKENS` + `filterTokenHint()` in `searchFilterService.js`, prefixes mirroring `buildFilterTokens`. Tested (range/flag/dice/text/date forms, unknown→`''`, token-prefix drift guard).

## On the "too heavy / verbose" concern

The hint is **word-free** (token + operators only) → **zero translation**, no prose added to the UI. The full filter prose reference already lives in `annexe_filtres.rst`. This is the minimal, hover-only variant.

Full frontend suite green (490).

🤖 Generated with [Claude Code](https://claude.com/claude-code)