### PR TITLE
feat(search): `pl"Name"` player filter (positions involving a player)

### DIFF
--- a/doc/source/cmd_mode.rst
+++ b/doc/source/cmd_mode.rst
@@ -206,6 +206,7 @@ c'est-à-dire après le début de commande ``s``.
    "tnx,y", "Rechercher dans les tournois d'identifiants x à y (ex: tn1,3)."
    "idx", "Rechercher la position d'identifiant x (ex: id12)."
    "idx,y", "Rechercher les positions d'identifiants x à y (ex: id5,10)."
+   "pl'nom'", "Rechercher les positions issues d'un match impliquant le joueur indiqué, sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
 
 
 .. note:: Filtrer les positions en fonction du lancer de dés (`D` ou `D1`)

--- a/doc/source/locale/de/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/de/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: de\n"
@@ -320,9 +320,11 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Lädt die größten Fehler (Equity/MWC) in die Analyseansicht, gemäß dem aktuellen Statistikfilter. Eine optionale Zahl wählt, wie viele geladen werden (``bl 50``); standardmäßig 10."
+msgstr ""
 "Lädt die größten Fehler (Equity/MWC) in die Analyseansicht, gemäß dem "
-"aktuellen Statistikfilter."
+"aktuellen Statistikfilter. Eine optionale Zahl wählt, wie viele geladen "
+"werden (``bl 50``); standardmäßig 10.Lädt die größten Fehler (Equity/MWC)"
+" in die Analyseansicht, gemäß dem aktuellen Statistikfilter."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1113,7 +1115,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Die Positionen mit den Kennungen x bis y suchen (z. B. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Stellungen aus einer Partie suchen, an der der genannte Spieler an einer der beiden Seiten beteiligt war (z. B. pl'Alice'). Groß-/Kleinschreibung wird ignoriert."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1127,7 +1139,7 @@ msgstr ""
 "ersten Würfels wird verwendet, um Positionen zuzuordnen (auf einem der "
 "beiden Würfel des Wurfs)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1141,7 +1153,7 @@ msgstr ""
 "mindestens 10 Pips in Führung. `p50,70`: Der Spieler liegt im Rennen "
 "zwischen 50 und 70 Pips zurück."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1153,7 +1165,7 @@ msgstr ""
 " 23 und 43). Dasselbe Prinzip gilt für Turniere mit ``tn`` und für "
 "Positionen mit ``id`` (z. B. ``s id5 id10`` für die Positionen 5 und 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1163,7 +1175,7 @@ msgstr ""
 "Matches des betreffenden Turniers. Die IDs der Matches und Turniere sind "
 "in den ID-Spalten der entsprechenden Panels sichtbar."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1179,7 +1191,7 @@ msgstr ""
 "Gewinnchancen, mindestens 10 Steinen in der Zone, und der Gegner zwischen"
 " 2 und 3 rückständige Steine hat."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Verschiedene Befehle"
 
@@ -1191,7 +1203,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Löscht den Befehlsverlauf."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/el/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/el/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: el\n"
@@ -320,9 +320,12 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Φορτώνει τα χειρότερα λάθη (equity/MWC) στην προβολή ανάλυσης, σύμφωνα με το τρέχον φίλτρο στατιστικών. Ένας προαιρετικός αριθμός επιλέγει πόσα θα φορτωθούν (``bl 50``)· προεπιλογή 10."
+msgstr ""
 "Φορτώνει τα χειρότερα λάθη (equity/MWC) στην προβολή ανάλυσης, σύμφωνα με"
-" το τρέχον φίλτρο στατιστικών."
+" το τρέχον φίλτρο στατιστικών. Ένας προαιρετικός αριθμός επιλέγει πόσα θα"
+" φορτωθούν (``bl 50``)· προεπιλογή 10.Φορτώνει τα χειρότερα λάθη "
+"(equity/MWC) στην προβολή ανάλυσης, σύμφωνα με το τρέχον φίλτρο "
+"στατιστικών."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1108,7 +1111,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Αναζήτηση των θέσεων με αναγνωριστικά από x έως y (π.χ. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Αναζήτηση θέσεων από αγώνα στον οποίο συμμετείχε ο αναφερόμενος παίκτης, σε οποιαδήποτε πλευρά (π.χ. pl'Alice'). Αγνοεί πεζά/κεφαλαία."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1122,7 +1135,7 @@ msgstr ""
 "ζαριού χρησιμοποιείται για την αντιστοίχιση των θέσεων (σε οποιοδήποτε "
 "από τα δύο ζάρια της ζαριάς)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1136,7 +1149,7 @@ msgstr ""
 "pips μπροστά στην κούρσα. `p50,70` : ο παίκτης είναι μεταξύ 50 και 70 "
 "pips πίσω στην κούρσα."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1148,7 +1161,7 @@ msgstr ""
 "ίδια αρχή ισχύει για τα τουρνουά με ``tn`` και για τις θέσεις με ``id`` "
 "(π.χ. ``s id5 id10`` για τις θέσεις 5 και 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1158,7 +1171,7 @@ msgstr ""
 "τους αγώνες του εν λόγω τουρνουά. Τα αναγνωριστικά των αγώνων και των "
 "τουρνουά είναι ορατά στις στήλες ID των αντίστοιχων πάνελ."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1174,7 +1187,7 @@ msgstr ""
 "τουλάχιστον 10 πούλια στη ζώνη, και ο αντίπαλος έχει μεταξύ 2 και 3 "
 "οπίσθια πούλια."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Διάφορες εντολές"
 
@@ -1186,7 +1199,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Διαγράφει το ιστορικό εντολών."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/en/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/en/LC_MESSAGES/cmd_mode.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: 2025-02-06 00:12+0100\n"
 "Last-Translator: unger <kevin.unger@proton.me>\n"
 "Language: en\n"
@@ -319,9 +319,11 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Load the worst mistakes (equity/MWC) into the analysis view, according to the current statistics filter. An optional number chooses how many to load (``bl 50``); 10 by default."
+msgstr ""
 "Load the worst mistakes (equity/MWC) into the analysis view, according to"
-" the current statistics filter."
+" the current statistics filter. An optional number chooses how many to "
+"load (``bl 50``); 10 by default.Load the worst mistakes (equity/MWC) into"
+" the analysis view, according to the current statistics filter."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1098,7 +1100,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Search for the positions with identifiers x to y (e.g. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Search positions from a match involving the named player, at either seat (e.g. pl'Alice'). Case-insensitive."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1111,7 +1123,7 @@ msgstr ""
 " filter ignores the second die: only the first die's value is used to "
 "match positions (against either die of the roll)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1125,7 +1137,7 @@ msgstr ""
 "ahead in the race. `p50,70`: the player is between 50 and 70 pips behind "
 "in the race."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1137,7 +1149,7 @@ msgstr ""
 " to tournaments with ``tn`` and to positions with ``id`` (e.g. ``s id5 "
 "id10`` for positions 5 and 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1147,7 +1159,7 @@ msgstr ""
 "that tournament. Match and tournament IDs are visible in the ID columns "
 "of the corresponding panels."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1162,7 +1174,7 @@ msgstr ""
 "ahead in the race, with at least 60% winning chances, at least 10 "
 "checkers in the zone, and the opponent has between 2 and 3 backcheckers."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Various commands"
 
@@ -1174,7 +1186,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Clear the command history."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/es/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/es/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: es\n"
@@ -320,9 +320,11 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Carga los peores errores (equity/MWC) en la vista de análisis, según el filtro de estadísticas actual. Un número opcional elige cuántos cargar (``bl 50``); 10 por defecto."
+msgstr ""
 "Carga los peores errores (equity/MWC) en la vista de análisis, según el "
-"filtro de estadísticas actual."
+"filtro de estadísticas actual. Un número opcional elige cuántos cargar "
+"(``bl 50``); 10 por defecto.Carga los peores errores (equity/MWC) en la "
+"vista de análisis, según el filtro de estadísticas actual."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1109,7 +1111,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Buscar las posiciones con identificadores de x a y (p. ej. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Buscar posiciones de una partida en la que participó el jugador indicado, en cualquier lado (p. ej. pl'Alice'). No distingue mayúsculas y minúsculas."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1123,7 +1135,7 @@ msgstr ""
 "del primer dado para emparejar las posiciones (sobre cualquiera de los "
 "dos dados de la tirada)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1137,7 +1149,7 @@ msgstr ""
 "menos 10 pips de ventaja en la carrera. `p50,70` : el jugador tiene entre"
 " 50 y 70 pips de desventaja en la carrera."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1149,7 +1161,7 @@ msgstr ""
 " principio se aplica a los torneos con ``tn`` y a las posiciones con "
 "``id`` (p. ej. ``s id5 id10`` para las posiciones 5 y 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1159,7 +1171,7 @@ msgstr ""
 "matches de dicho torneo. Los identificadores de los matches y de los "
 "torneos son visibles en las columnas ID de los paneles correspondientes."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1175,7 +1187,7 @@ msgstr ""
 " al menos 10 fichas en la zona, y el adversario tiene entre 2 y 3 fichas "
 "rezagadas."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Comandos diversos"
 
@@ -1187,7 +1199,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Borra el historial de comandos."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/fi/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/fi/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fi\n"
@@ -320,9 +320,11 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Lataa pahimmat virheet (equity/MWC) analyysinäkymään nykyisen tilastosuodattimen mukaisesti. Valinnainen luku valitsee, kuinka monta ladataan (``bl 50``); oletuksena 10."
+msgstr ""
 "Lataa pahimmat virheet (equity/MWC) analyysinäkymään nykyisen "
-"tilastosuodattimen mukaisesti."
+"tilastosuodattimen mukaisesti. Valinnainen luku valitsee, kuinka monta "
+"ladataan (``bl 50``); oletuksena 10.Lataa pahimmat virheet (equity/MWC) "
+"analyysinäkymään nykyisen tilastosuodattimen mukaisesti."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1096,7 +1098,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Hae asemia, joiden tunnukset ovat välillä x–y (esim. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Hae asemia ottelusta, jossa nimetty pelaaja oli mukana kummalla tahansa puolella (esim. pl'Alice'). Kirjainkoolla ei ole väliä."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1110,7 +1122,7 @@ msgstr ""
 "ensimmäisen nopan arvoa käytetään asemien täsmäykseen (jommankumman "
 "heiton nopan kanssa)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1124,7 +1136,7 @@ msgstr ""
 "vähintään 10 pippiä edellä. `p50,70` : pelaaja on kilpajuoksussa 50–70 "
 "pippiä jäljessä."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1136,7 +1148,7 @@ msgstr ""
 " pätee turnauksiin suodattimella ``tn`` ja asemiin suodattimella ``id`` "
 "(esim. ``s id5 id10`` asemille 5 ja 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1146,7 +1158,7 @@ msgstr ""
 "kaikista otteluista. Otteluiden ja turnausten tunnukset näkyvät "
 "vastaavien paneelien ID-sarakkeissa."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1161,7 +1173,7 @@ msgstr ""
 "vyöhykkeellä on vähintään 10 nappulaa, vastustajalla on 2–3 takanappulaa "
 "ja voittomahdollisuudet ovat vähintään 60%."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Sekalaisia komentoja"
 
@@ -1173,7 +1185,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Tyhjentää komentohistorian."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/fr/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/fr/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: blunderDB \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: fr\n"
@@ -1067,7 +1067,17 @@ msgstr ""
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr ""
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1076,7 +1086,7 @@ msgid ""
 "l'autre des deux dés du lancer)."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1085,7 +1095,7 @@ msgid ""
 "retard à la course."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1093,14 +1103,14 @@ msgid ""
 "positions avec ``id`` (ex: ``s id5 id10`` pour les positions 5 et 10)."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
 "tournois sont visibles dans les colonnes ID des panneaux correspondants."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1110,7 +1120,7 @@ msgid ""
 "la zone, et l'adversaire a entre 2 et 3 pions arriérés."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr ""
 
@@ -1122,7 +1132,7 @@ msgstr ""
 msgid "Efface l'historique des commandes."
 msgstr ""
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/it/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/it/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: it\n"
@@ -318,9 +318,12 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Carica gli errori peggiori (equity/MWC) nella vista di analisi, secondo il filtro statistico corrente. Un numero opzionale sceglie quanti caricarne (``bl 50``); 10 per impostazione predefinita."
+msgstr ""
 "Carica gli errori peggiori (equity/MWC) nella vista di analisi, secondo "
-"il filtro statistico corrente."
+"il filtro statistico corrente. Un numero opzionale sceglie quanti "
+"caricarne (``bl 50``); 10 per impostazione predefinita.Carica gli errori "
+"peggiori (equity/MWC) nella vista di analisi, secondo il filtro "
+"statistico corrente."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1104,7 +1107,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Cercare le posizioni con identificativi da x a y (es. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Cerca posizioni di una partita a cui ha partecipato il giocatore indicato, su entrambi i lati (es. pl'Alice'). Non distingue maiuscole e minuscole."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1118,7 +1131,7 @@ msgstr ""
 "dado viene usato per far corrispondere le posizioni (su uno qualsiasi dei"
 " due dadi del lancio)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1132,7 +1145,7 @@ msgstr ""
 "pip di vantaggio nella corsa. `p50,70` : il giocatore ha tra 50 e 70 pip "
 "di svantaggio nella corsa."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1144,7 +1157,7 @@ msgstr ""
 "si applica ai tornei con ``tn`` e alle posizioni con ``id`` (es. ``s id5 "
 "id10`` per le posizioni 5 e 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1154,7 +1167,7 @@ msgstr ""
 "torneo interessato. Gli identificatori delle partite e dei tornei sono "
 "visibili nelle colonne ID dei pannelli corrispondenti."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1170,7 +1183,7 @@ msgstr ""
 "almeno 10 pedine nella zona, e l'avversario ha tra 2 e 3 pedine "
 "arretrate."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Comandi vari"
 
@@ -1182,7 +1195,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Cancella la cronologia dei comandi."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/ja/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/ja/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ja\n"
@@ -375,8 +375,9 @@ msgid ""
 "structure de pions courante, ignore la position du videau, du score et "
 "des dés. Pour prendre en compte la position du videau, du score, des dés,"
 " il faut le mentionner explicitement dans la recherche."
-msgstr "現在の統計フィルターに従って、最悪のミス（エクイティ/MWC）を分析ビューに読み込みます。オプションの数値で読み込む件数を指定できます（``bl 50``）。既定値は10です。"
-"局面検索では、デフォルトで blunderDB "
+msgstr ""
+"現在の統計フィルターに従って、最悪のミス（エクイティ/MWC）を分析ビューに読み込みます。オプションの数値で読み込む件数を指定できます（``bl "
+"50``）。既定値は10です。局面検索では、デフォルトで blunderDB "
 "は現在の駒の配置を考慮し、キューブ、スコア、ダイスの状態は無視します。キューブ、スコア、ダイスを考慮させるには、検索時に明示的に指定する必要があります。"
 
 #: ../../source/cmd_mode.rst:102
@@ -1074,7 +1075,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "識別子 x から y までのポジションを検索します（例: id5,10）。"
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "指定したプレイヤーが（どちらの席でも）参加した対局の局面を検索します（例：pl'Alice'）。大文字・小文字は区別しません。"
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1086,7 +1097,7 @@ msgstr ""
 " `D1` は 2 つ目のダイスの値を無視します。局面のマッチには 1 つ目のダイスの値のみが使われます（出目の 2 "
 "つのダイスのいずれかに対して）。"
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1098,7 +1109,7 @@ msgstr ""
 "のとき進んでいます。例: `p<-10` : プレイヤーがレースで少なくとも 10 ピップ進んでいます。`p50,70` : プレイヤーがレースで"
 " 50 から 70 ピップ遅れています。"
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1109,7 +1120,7 @@ msgstr ""
 "ma23 ma43`` ）。同じ原則がトーナメントの ``tn`` にも、ポジションの ``id`` にも適用されます（例: ポジション 5 と "
 "10 の場合は ``s id5 id10`` ）。"
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1118,7 +1129,7 @@ msgstr ""
 "トーナメント（``tn``）内を検索することは、該当トーナメントのすべてのマッチ内を検索することと同じです。マッチとトーナメントの識別子は、対応するパネルの"
 " ID 列で確認できます。"
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1131,7 +1142,7 @@ msgstr ""
 "は、編集中の局面の駒の配置、スコア、キューブを考慮し、プレイヤーがレースで 20 から 5 ピップ進んでおり、勝率が少なくとも "
 "60%、ゾーン内に少なくとも 10 個の駒があり、相手が 2 から 3 個の後方の駒を持つすべての局面をフィルタします。"
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "その他のコマンド"
 
@@ -1143,7 +1154,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "コマンド履歴を消去します。"
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/doc/source/locale/ru/LC_MESSAGES/cmd_mode.po
+++ b/doc/source/locale/ru/LC_MESSAGES/cmd_mode.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version:  blunderDB\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-13 02:53+0200\n"
+"POT-Creation-Date: 2026-06-13 03:30+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: ru\n"
@@ -321,9 +321,12 @@ msgid ""
 "Charger les pires erreurs (équité/MWC) dans la vue d'analyse, selon le "
 "filtre courant des statistiques. Un nombre optionnel choisit combien en "
 "charger (``bl 50``) ; par défaut 10."
-msgstr "Загружает худшие ошибки (equity/MWC) в представление анализа согласно текущему фильтру статистики. Необязательное число задаёт, сколько загрузить (``bl 50``); по умолчанию 10."
+msgstr ""
 "Загружает худшие ошибки (equity/MWC) в представление анализа согласно "
-"текущему фильтру статистики."
+"текущему фильтру статистики. Необязательное число задаёт, сколько "
+"загрузить (``bl 50``); по умолчанию 10.Загружает худшие ошибки "
+"(equity/MWC) в представление анализа согласно текущему фильтру "
+"статистики."
 
 #: ../../source/cmd_mode.rst:1
 msgid "m"
@@ -1097,7 +1100,17 @@ msgstr "idx,y"
 msgid "Rechercher les positions d'identifiants x à y (ex: id5,10)."
 msgstr "Найти позиции с идентификаторами от x до y (напр. id5,10)."
 
-#: ../../source/cmd_mode.rst:211
+#: ../../source/cmd_mode.rst:1
+msgid "pl'nom'"
+msgstr ""
+
+#: ../../source/cmd_mode.rst:1
+msgid ""
+"Rechercher les positions issues d'un match impliquant le joueur indiqué, "
+"sur l'un ou l'autre camp (ex: pl'Alice'). La casse est ignorée."
+msgstr "Поиск позиций из матча с участием указанного игрока на любой стороне (напр. pl'Alice'). Без учёта регистра."
+
+#: ../../source/cmd_mode.rst:212
 msgid ""
 "Filtrer les positions en fonction du lancer de dés (`D` ou `D1`) implique"
 " *a fortiori* de filtrer les positions en fonction du type de décision "
@@ -1110,7 +1123,7 @@ msgstr ""
 "игнорирует значение второго кубика: только значение первого кубика "
 "используется для сопоставления позиций (с любым из двух кубиков броска)."
 
-#: ../../source/cmd_mode.rst:217
+#: ../../source/cmd_mode.rst:218
 msgid ""
 "Pour le filtre de différence relative à la course (`p>x`, `p<x`, `px,y`),"
 " le joueur est en retard à la course par rapport à l'adversaire si `x>0` "
@@ -1123,7 +1136,7 @@ msgstr ""
 "Пример: `p<-10`: игрок опережает как минимум на 10 пипов. `p50,70`: игрок"
 " отстаёт на 50–70 пипов в гонке."
 
-#: ../../source/cmd_mode.rst:223
+#: ../../source/cmd_mode.rst:224
 msgid ""
 "Pour rechercher dans plusieurs matchs non contigus, juxtaposer le filtre "
 "``ma`` plusieurs fois (ex: ``s ma23 ma43`` pour les matchs 23 et 43). Le "
@@ -1135,7 +1148,7 @@ msgstr ""
 "применяется к турнирам с ``tn`` и к позициям с ``id`` (напр. ``s id5 "
 "id10`` для позиций 5 и 10)."
 
-#: ../../source/cmd_mode.rst:228
+#: ../../source/cmd_mode.rst:229
 msgid ""
 "Rechercher dans un tournoi (``tn``) revient à rechercher dans l'ensemble "
 "des matchs du tournoi concerné. Les identifiants des matchs et des "
@@ -1145,7 +1158,7 @@ msgstr ""
 "Идентификаторы матчей и турниров видны в столбцах ID соответствующих "
 "панелей."
 
-#: ../../source/cmd_mode.rst:232
+#: ../../source/cmd_mode.rst:233
 #, python-format
 msgid ""
 "Par exemple, la commande ``s s c p-20,-5 w>60 z>10 K2,3`` filtre toutes "
@@ -1159,7 +1172,7 @@ msgstr ""
 "игрока от 20 до 5 пипов преимущества в гонке, вероятность победы не менее"
 " 60%, не менее 10 шашек в зоне, и у противника от 2 до 3 задних шашек."
 
-#: ../../source/cmd_mode.rst:242
+#: ../../source/cmd_mode.rst:243
 msgid "Commandes diverses"
 msgstr "Прочие команды"
 
@@ -1171,7 +1184,7 @@ msgstr "clear, cl"
 msgid "Efface l'historique des commandes."
 msgstr "Очищает историю команд."
 
-#: ../../source/cmd_mode.rst:251
+#: ../../source/cmd_mode.rst:252
 msgid ""
 "Les migrations de base de données sont désormais effectuées "
 "automatiquement lors de l'ouverture d'une base de données."

--- a/frontend/src/__tests__/commandProcessor.test.js
+++ b/frontend/src/__tests__/commandProcessor.test.js
@@ -41,6 +41,23 @@ describe('parseFilters', () => {
         expect(result.winRateFilter).toBeUndefined();
         expect(result.matchIDsFilter).toBe('');
         expect(result.tournamentIDsFilter).toBe('');
+        expect(result.playerFilter).toBe('');
+    });
+
+    // -- player filter -------------------------------------------------------
+    test('extracts playerFilter from pl"Name"', () => {
+        expect(parseFilters(['pl"Alice"'], 's pl"Alice"').playerFilter).toBe('pl"Alice"');
+    });
+
+    test('playerFilter keeps names with spaces (matched on the raw command)', () => {
+        const r = parseFilters(['pl"Kévin', 'Unger"'], 's pl"Kévin Unger"');
+        expect(r.playerFilter).toBe('pl"Kévin Unger"');
+    });
+
+    test('pl"…" does not corrupt the pipcount filter', () => {
+        const r = parseFilters(['pl"Bob"', 'p>120'], 's pl"Bob" p>120');
+        expect(r.playerFilter).toBe('pl"Bob"');
+        expect(r.pipCountFilter).toBe('p>120');
     });
 
     // -- boolean flags -------------------------------------------------------

--- a/frontend/src/__tests__/searchFilterService.test.js
+++ b/frontend/src/__tests__/searchFilterService.test.js
@@ -382,3 +382,30 @@ describe('filterTokenHint', () => {
         }
     });
 });
+
+describe('Player filter token', () => {
+    test('buildFilterTokens emits pl"Name" for the Player filter', () => {
+        expect(buildFilterTokens(['Player'], { playerName: 'Alice' })).toEqual(['pl"Alice"']);
+        expect(buildFilterTokens(['Player'], { playerName: 'Kévin Unger' })).toEqual(['pl"Kévin Unger"']);
+    });
+
+    test('parseFilterTokens extracts plFilter without stealing the pipcount token', () => {
+        const p = parseFilterTokens(['pl"Bob"', 'p>120']);
+        expect(p.plFilter).toBe('pl"Bob"');
+        expect(p.pcFilter).toBe('p>120'); // pl"…" must NOT be picked as the pipcount
+    });
+
+    test('parseFilterTokens: pl absent leaves plFilter undefined and pipcount intact', () => {
+        const p = parseFilterTokens(['p<60']);
+        expect(p.plFilter).toBeUndefined();
+        expect(p.pcFilter).toBe('p<60');
+    });
+
+    test('filterTokenHint shows the quoted-text form for Player', () => {
+        expect(filterTokenHint('Player')).toBe('pl"…"');
+    });
+
+    test('buildSearchCommand drops an empty pl"" token', () => {
+        expect(buildSearchCommand(['cube', 'pl""'])).toBe('s cube');
+    });
+});

--- a/frontend/src/commandProcessor.js
+++ b/frontend/src/commandProcessor.js
@@ -262,7 +262,8 @@ function handleSubSearch(command, positions) {
                 currentIDs,
                 false,
                 parsedFilters.diceRollMode,
-                parsedFilters.positionIDsFilter
+                parsedFilters.positionIDsFilter,
+                parsedFilters.playerFilter
             );
         }
     } else {
@@ -366,7 +367,8 @@ function handleSearch(command) {
                 '',
                 false,
                 parsedFilters.diceRollMode,
-                parsedFilters.positionIDsFilter
+                parsedFilters.positionIDsFilter,
+                parsedFilters.playerFilter
             );
         }
     } else {
@@ -385,7 +387,8 @@ export function parseFilters(filters, command) {
     // 'x' marks that an exclusion ("Sauf") structure is active. The structure
     // itself is carried by the exclude board (store), like the include structure.
     const excludeStructure = filters.includes('x');
-    const pipCountFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('p>') || f.startsWith('p<') || f.startsWith('p')));
+    // Exclude `pl"…"` (player filter) — it starts with 'p' but is not a pipcount.
+    const pipCountFilter = filters.find((f) => typeof f === 'string' && !f.startsWith('pl') && (f.startsWith('p>') || f.startsWith('p<') || f.startsWith('p')));
     const winRateFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('w>') || f.startsWith('w<') || f.startsWith('w')));
     const gammonRateFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('g>') || f.startsWith('g<') || f.startsWith('g')));
     const backgammonRateFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('b>') || f.startsWith('b<') || (f.startsWith('b') && !f.startsWith('bo'))) && !f.startsWith('bj'));
@@ -423,6 +426,10 @@ export function parseFilters(filters, command) {
     const movePatternFilter = movePatternMatch ? movePatternMatch[0] : '';
     const searchTextMatch = command.match(/t["'][^"']*["']/);
     const searchText = searchTextMatch ? searchTextMatch[0] : '';
+    // Player filter `pl"Name"` — matched on the raw command so names with spaces
+    // survive (the space-split `filters` array would break them).
+    const playerMatch = command.match(/pl["'][^"']*["']/);
+    const playerFilter = playerMatch ? playerMatch[0] : '';
     const player1OutfieldBlotFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('bo>') || f.startsWith('bo<') || f.startsWith('bo')));
     const player2OutfieldBlotFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('BO>') || f.startsWith('BO<') || f.startsWith('BO')));
     const player1JanBlotFilter = filters.find((f) => typeof f === 'string' && (f.startsWith('bj>') || f.startsWith('bj<') || f.startsWith('bj')));
@@ -486,6 +493,7 @@ export function parseFilters(filters, command) {
         moveErrorFilter,
         matchIDsFilter,
         tournamentIDsFilter,
+        playerFilter,
         positionIDsFilter
     };
 }

--- a/frontend/src/components/SearchPanel.svelte
+++ b/frontend/src/components/SearchPanel.svelte
@@ -26,6 +26,7 @@
     let movePattern = $state('');
     let matchIDsInput = $state('');
     let tournamentIDsInput = $state('');
+    let playerName = $state('');
 
     let pipCountOption = $state('min');
     let pipCountMin = $state(-375);
@@ -184,7 +185,8 @@
         'Best Move or Cube Decision',
         'Creation Date',
         'Match IDs',
-        'Tournament IDs'
+        'Tournament IDs',
+        'Player'
     ];
 
     // Canonical filter/group names stay in English because they double as logic
@@ -222,7 +224,8 @@
         'Best Move or Cube Decision': 'bestMoveOrCubeDecision',
         'Creation Date': 'creationDate',
         'Match IDs': 'matchIDs',
-        'Tournament IDs': 'tournamentIDs'
+        'Tournament IDs': 'tournamentIDs',
+        Player: 'player'
     };
     const groupKeySlug = {
         Display: 'display',
@@ -255,7 +258,7 @@
         { name: 'Checkers', filters: ['Player Checker-Off', 'Opponent Checker-Off', 'Player Back Checker', 'Opponent Back Checker', 'Player Checker in the Zone', 'Opponent Checker in the Zone'] },
         { name: 'Blots', filters: ['Player Outfield Blot', 'Opponent Outfield Blot', 'Player Jan Blot', 'Opponent Jan Blot'] },
         { name: 'Text / Pattern', filters: ['Search Text', 'Best Move or Cube Decision'] },
-        { name: 'Other', filters: ['Creation Date', 'Match IDs', 'Tournament IDs'] }
+        { name: 'Other', filters: ['Creation Date', 'Match IDs', 'Tournament IDs', 'Player'] }
     ];
 
     // Which structure the main board is currently editing: 'include' (au moins)
@@ -550,7 +553,8 @@
             player2JanBlotRangeMin,
             player2JanBlotRangeMax,
             matchIDsInput,
-            tournamentIDsInput
+            tournamentIDsInput,
+            playerName
         });
 
         // Cube sub-type: when the decision-type filter constrains to a cube
@@ -645,7 +649,9 @@
             tournamentIDs,
             restrictToPositionIDs,
             openInNewTab,
-            drMode
+            drMode,
+            '',
+            playerName ? `pl"${playerName}"` : ''
         );
 
         saveSearchState();
@@ -762,6 +768,7 @@
         searchOfferedCubeStore.set(false);
         matchIDsInput = '';
         tournamentIDsInput = '';
+        playerName = '';
         creationDateOption = 'min';
         creationDateMin = '';
         creationDateMax = '';
@@ -823,7 +830,7 @@
             const dr = cmdFilters.includes('D') || cmdFilters.includes('D1');
             const drMode = cmdFilters.includes('D1') ? 'first' : 'both';
             const mp = cmdFilters.includes('M');
-            const pc = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('p>') || f.startsWith('p<') || f.startsWith('p')));
+            const pc = cmdFilters.find((f) => typeof f === 'string' && !f.startsWith('pl') && (f.startsWith('p>') || f.startsWith('p<') || f.startsWith('p')));
             const wr = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('w>') || f.startsWith('w<') || f.startsWith('w')));
             const gr = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('g>') || f.startsWith('g<') || f.startsWith('g')));
             const bg = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('b>') || f.startsWith('b<') || (f.startsWith('b') && !f.startsWith('bo'))) && !f.startsWith('bj'));
@@ -849,6 +856,8 @@
             const mpf = mpm ? mpm[0] : '';
             const stm = command.match(/t["'][^"']*["']/);
             const st = stm ? stm[0] : '';
+            const plm = command.match(/pl["'][^"']*["']/);
+            const plf = plm ? plm[0] : '';
             const p1ob = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('bo>') || f.startsWith('bo<') || f.startsWith('bo')));
             const p2ob = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('BO>') || f.startsWith('BO<') || f.startsWith('BO')));
             const p1jb = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('bj>') || f.startsWith('bj<') || f.startsWith('bj')));
@@ -894,7 +903,9 @@
                 tournamentIDs,
                 '',
                 false,
-                drMode
+                drMode,
+                '',
+                plf
             );
         }
     }
@@ -1019,6 +1030,7 @@
             movePattern,
             matchIDsInput,
             tournamentIDsInput,
+            playerName,
             pipCountOption,
             pipCountMin,
             pipCountMax,
@@ -1157,6 +1169,7 @@
         movePattern = saved.movePattern;
         matchIDsInput = saved.matchIDsInput;
         tournamentIDsInput = saved.tournamentIDsInput;
+        playerName = saved.playerName ?? '';
         pipCountOption = saved.pipCountOption;
         pipCountMin = saved.pipCountMin;
         pipCountMax = saved.pipCountMax;
@@ -2039,6 +2052,10 @@
                                                         class="text-input"
                                                         placeholder={$t('search.idOrRange')}
                                                     />
+                                                </div>
+                                            {:else if filter === 'Player'}
+                                                <div class="text-control">
+                                                    <span class="hint">{$t('search.playerHint')}</span><input type="text" bind:value={playerName} class="text-input" />
                                                 </div>
                                             {/if}
                                         </div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Suchtext",
         "selectFilter": "Filter auswählen",
         "tournamentIdsHint": "Turnier-IDs",
+        "playerHint": "Spielername (beide Seiten)",
         "decision": {
             "checker": "Zug",
             "cube": "Dopplung",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Bester Zug oder Dopplerentscheidung",
             "creationDate": "Erstellungsdatum",
             "matchIDs": "Match-IDs",
-            "tournamentIDs": "Turnier-IDs"
+            "tournamentIDs": "Turnier-IDs",
+            "player": "Spieler"
         },
         "filterGroups": {
             "display": "Anzeige",

--- a/frontend/src/i18n/locales/el.json
+++ b/frontend/src/i18n/locales/el.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Κείμενο αναζήτησης",
         "selectFilter": "Επιλέξτε ένα φίλτρο",
         "tournamentIdsHint": "ID τουρνουά",
+        "playerHint": "Όνομα παίκτη (οποιαδήποτε πλευρά)",
         "decision": {
             "checker": "Πιόνια",
             "cube": "Κύβος",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Καλύτερη κίνηση ή απόφαση κύβου",
             "creationDate": "Ημερομηνία δημιουργίας",
             "matchIDs": "Αναγνωριστικά αγώνα",
-            "tournamentIDs": "Αναγνωριστικά τουρνουά"
+            "tournamentIDs": "Αναγνωριστικά τουρνουά",
+            "player": "Παίκτης"
         },
         "filterGroups": {
             "display": "Εμφάνιση",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Search text",
         "selectFilter": "Select a filter",
         "tournamentIdsHint": "Tournament IDs",
+        "playerHint": "Player name (either side)",
         "decision": {
             "checker": "Checker",
             "cube": "Cube",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Best Move or Cube Decision",
             "creationDate": "Creation Date",
             "matchIDs": "Match IDs",
-            "tournamentIDs": "Tournament IDs"
+            "tournamentIDs": "Tournament IDs",
+            "player": "Player"
         },
         "filterGroups": {
             "display": "Display",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Texto de búsqueda",
         "selectFilter": "Selecciona un filtro",
         "tournamentIdsHint": "ID de torneos",
+        "playerHint": "Nombre del jugador (cualquier lado)",
         "decision": {
             "checker": "Fichas",
             "cube": "Cubo",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Mejor jugada o decisión de cubo",
             "creationDate": "Fecha de creación",
             "matchIDs": "ID de partida",
-            "tournamentIDs": "ID de torneo"
+            "tournamentIDs": "ID de torneo",
+            "player": "Jugador"
         },
         "filterGroups": {
             "display": "Visualización",

--- a/frontend/src/i18n/locales/fi.json
+++ b/frontend/src/i18n/locales/fi.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Hakuteksti",
         "selectFilter": "Valitse suodatin",
         "tournamentIdsHint": "Turnaustunnukset",
+        "playerHint": "Pelaajan nimi (kumpi tahansa)",
         "decision": {
             "checker": "Siirto",
             "cube": "Tuplaus",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Paras siirto tai kuutiopäätös",
             "creationDate": "Luontipäivä",
             "matchIDs": "Ottelun tunnukset",
-            "tournamentIDs": "Turnauksen tunnukset"
+            "tournamentIDs": "Turnauksen tunnukset",
+            "player": "Pelaaja"
         },
         "filterGroups": {
             "display": "Näyttö",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Texte de recherche",
         "selectFilter": "Sélectionner un filtre",
         "tournamentIdsHint": "ID de tournoi",
+        "playerHint": "Nom du joueur (l'un ou l'autre camp)",
         "decision": {
             "checker": "Pions",
             "cube": "Videau",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Meilleur coup ou décision de videau",
             "creationDate": "Date de création",
             "matchIDs": "ID de match",
-            "tournamentIDs": "ID de tournoi"
+            "tournamentIDs": "ID de tournoi",
+            "player": "Joueur"
         },
         "filterGroups": {
             "display": "Affichage",

--- a/frontend/src/i18n/locales/it.json
+++ b/frontend/src/i18n/locales/it.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Testo da cercare",
         "selectFilter": "Seleziona un filtro",
         "tournamentIdsHint": "ID dei tornei",
+        "playerHint": "Nome del giocatore (entrambi i lati)",
         "decision": {
             "checker": "Pedine",
             "cube": "Cubo",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Mossa migliore o decisione di cubo",
             "creationDate": "Data di creazione",
             "matchIDs": "ID partita",
-            "tournamentIDs": "ID torneo"
+            "tournamentIDs": "ID torneo",
+            "player": "Giocatore"
         },
         "filterGroups": {
             "display": "Visualizzazione",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -230,6 +230,7 @@
         "searchTextHint": "検索テキスト",
         "selectFilter": "フィルターを選択",
         "tournamentIdsHint": "トーナメント ID",
+        "playerHint": "プレイヤー名（どちらの席でも）",
         "decision": {
             "checker": "チェッカー",
             "cube": "キューブ",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "最善手またはキューブ判断",
             "creationDate": "作成日",
             "matchIDs": "マッチID",
-            "tournamentIDs": "トーナメントID"
+            "tournamentIDs": "トーナメントID",
+            "player": "プレイヤー"
         },
         "filterGroups": {
             "display": "表示",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -230,6 +230,7 @@
         "searchTextHint": "Текст поиска",
         "selectFilter": "Выберите фильтр",
         "tournamentIdsHint": "ID турниров",
+        "playerHint": "Имя игрока (любая сторона)",
         "decision": {
             "checker": "Шашки",
             "cube": "Куб",
@@ -268,7 +269,8 @@
             "bestMoveOrCubeDecision": "Лучший ход или решение по кубу",
             "creationDate": "Дата создания",
             "matchIDs": "ID матчей",
-            "tournamentIDs": "ID турниров"
+            "tournamentIDs": "ID турниров",
+            "player": "Игрок"
         },
         "filterGroups": {
             "display": "Отображение",

--- a/frontend/src/services/positionService.js
+++ b/frontend/src/services/positionService.js
@@ -357,7 +357,8 @@ export async function loadPositionsByFilters(
     restrictToPositionIDs = '',
     openInNewTab = false,
     diceRollMode = 'both',
-    positionIDsFilter = ''
+    positionIDsFilter = '',
+    playerFilter = ''
 ) {
     if (!get(databasePathStore)) {
         setStatusBarMessage(tMsg('commands.noDatabaseOpened'));
@@ -442,6 +443,7 @@ export async function loadPositionsByFilters(
             moveErrorFilter,
             matchIDsFilter,
             tournamentIDsFilter,
+            playerFilter,
             positionIDsFilter,
             restrictToPositionIDs
         });

--- a/frontend/src/services/searchFilterService.js
+++ b/frontend/src/services/searchFilterService.js
@@ -130,7 +130,8 @@ export function buildFilterTokens(activeFilters, options) {
         player2JanBlotRangeMin,
         player2JanBlotRangeMax,
         matchIDsInput,
-        tournamentIDsInput
+        tournamentIDsInput,
+        playerName
     } = options;
 
     return activeFilters.map((filter) => {
@@ -217,6 +218,8 @@ export function buildFilterTokens(activeFilters, options) {
                       : `Z${player2CheckerInZoneRangeMin},${player2CheckerInZoneRangeMax}`;
             case 'Search Text':
                 return `t"${searchText}"`;
+            case 'Player':
+                return `pl"${playerName}"`;
             case 'Best Move or Cube Decision':
                 return `m"${movePattern}"`;
             case 'Creation Date': {
@@ -270,7 +273,7 @@ export function buildFilterTokens(activeFilters, options) {
 export function buildSearchCommand(tokens) {
     const commandParts = ['s'];
     tokens.forEach((token) => {
-        if (token !== 't""' && token !== 'm""') {
+        if (token !== 't""' && token !== 'm""' && token !== 'pl""') {
             commandParts.push(token);
         }
     });
@@ -304,7 +307,8 @@ export function parseFilterTokens(tokens) {
         incScore: tokens.includes('score'),
         ncFilter: tokens.includes('nc'),
         mirFilter: tokens.includes('M'),
-        pcFilter: tokens.find((f) => f.startsWith('p')),
+        pcFilter: tokens.find((f) => f.startsWith('p') && !f.startsWith('pl')),
+        plFilter: tokens.find((f) => f.startsWith('pl')),
         wrFilter: tokens.find((f) => f.startsWith('w')),
         grFilter: tokens.find((f) => f.startsWith('g')),
         bgFilter: tokens.find((f) => f.startsWith('b') && !f.startsWith('bo') && !f.startsWith('bj')),
@@ -372,6 +376,7 @@ const FILTER_TOKENS = {
     'Opponent Jan Blot': { token: 'BJ', type: 'range' },
     'Search Text': { token: 't', type: 'text' },
     'Best Move or Cube Decision': { token: 'm', type: 'text' },
+    Player: { token: 'pl', type: 'text' },
     'Creation Date': { token: 'T', type: 'date' }
 };
 

--- a/pkg/blunderdb/database/search_player_test.go
+++ b/pkg/blunderdb/database/search_player_test.go
@@ -1,0 +1,82 @@
+package database
+
+// search_player_test.go — regression tests for the `pl"Name"` player filter,
+// which keeps positions occurring in any match where the named player sat at
+// either seat (SearchFilters.PlayerFilter, resolved by the storage search via a
+// position→move→game→match subquery).
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSearchPlayerFilter(t *testing.T) {
+	dir := t.TempDir()
+	db := NewDatabase()
+	if err := db.SetupDatabase(filepath.Join(dir, "search_player.db")); err != nil {
+		t.Fatalf("SetupDatabase: %v", err)
+	}
+	defer db.Close()
+
+	importTestMatch(t, db)
+
+	matches, err := db.GetAllMatches()
+	if err != nil {
+		t.Fatalf("GetAllMatches: %v", err)
+	}
+	if len(matches) == 0 {
+		t.Fatal("no match imported")
+	}
+	p1 := matches[0].Player1Name
+	p2 := matches[0].Player2Name
+	if p1 == "" {
+		t.Skip("imported match carries no player1 name")
+	}
+
+	all, err := db.LoadPositionsByFilters(SearchFilters{})
+	if err != nil {
+		t.Fatalf("LoadPositionsByFilters(all): %v", err)
+	}
+	if len(all) == 0 {
+		t.Fatal("no positions imported")
+	}
+
+	// The match's player (player 1) selects the match's positions.
+	got, err := db.LoadPositionsByFilters(SearchFilters{PlayerFilter: p1})
+	if err != nil {
+		t.Fatalf("LoadPositionsByFilters(player1): %v", err)
+	}
+	if len(got) == 0 {
+		t.Errorf("PlayerFilter=%q returned no positions", p1)
+	}
+
+	// Either seat matches: player 2 selects the same single-match positions.
+	if p2 != "" && p2 != p1 {
+		got2, err := db.LoadPositionsByFilters(SearchFilters{PlayerFilter: p2})
+		if err != nil {
+			t.Fatalf("LoadPositionsByFilters(player2): %v", err)
+		}
+		if len(got2) == 0 {
+			t.Errorf("PlayerFilter=%q (opponent seat) returned no positions", p2)
+		}
+	}
+
+	// Matching is case-insensitive.
+	lower, err := db.LoadPositionsByFilters(SearchFilters{PlayerFilter: strings.ToLower(p1)})
+	if err != nil {
+		t.Fatalf("LoadPositionsByFilters(player1 lowercased): %v", err)
+	}
+	if len(lower) != len(got) {
+		t.Errorf("case-insensitive mismatch: %q=%d positions, lowercased=%d", p1, len(got), len(lower))
+	}
+
+	// A name in no match returns nothing (the filter is exclusive, not a no-op).
+	none, err := db.LoadPositionsByFilters(SearchFilters{PlayerFilter: "ZZ_NoSuchPlayer_ZZ"})
+	if err != nil {
+		t.Fatalf("LoadPositionsByFilters(unknown): %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("unknown player returned %d positions, want 0", len(none))
+	}
+}

--- a/pkg/blunderdb/domain/domain.go
+++ b/pkg/blunderdb/domain/domain.go
@@ -185,8 +185,10 @@ type SearchFilters struct {
 	MoveErrorFilter               string   `json:"moveErrorFilter"`
 	MatchIDsFilter                string   `json:"matchIDsFilter"`
 	TournamentIDsFilter           string   `json:"tournamentIDsFilter"`
-	PositionIDsFilter             string   `json:"positionIDsFilter"`
-	RestrictToPositionIDs         string   `json:"restrictToPositionIDs"`
+	PlayerFilter                  string   `json:"playerFilter"` // exact player name (either seat); empty = no filter
+
+	PositionIDsFilter     string `json:"positionIDsFilter"`
+	RestrictToPositionIDs string `json:"restrictToPositionIDs"`
 }
 
 // ExportOptions bundles all parameters for ExportDatabase.

--- a/pkg/blunderdb/storage/postgres/search_player_postgres_test.go
+++ b/pkg/blunderdb/storage/postgres/search_player_postgres_test.go
@@ -1,0 +1,82 @@
+//go:build postgres
+
+// Validates the PostgreSQL player filter (ILIKE clause in search_postgres.go) on
+// a real database: import an XG match through the legacy Database, migrate it
+// into a fresh tenant, then search by player name via the storage backend.
+// Needs Docker; gated behind the `postgres` build tag.
+package postgres_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/kevung/blunderdb/pkg/blunderdb/database"
+	"github.com/kevung/blunderdb/pkg/blunderdb/domain"
+	"github.com/kevung/blunderdb/pkg/blunderdb/migrate"
+	pg "github.com/kevung/blunderdb/pkg/blunderdb/storage/postgres"
+	"github.com/kevung/blunderdb/pkg/blunderdb/storage/sqlite"
+)
+
+func findPlayer(t *testing.T, dst *pg.Storage, scope string, f domain.SearchFilters) int {
+	t.Helper()
+	n := 0
+	for _, err := range dst.Search().Find(context.Background(), scope, f) {
+		if err != nil {
+			t.Fatalf("Search.Find: %v", err)
+		}
+		n++
+	}
+	return n
+}
+
+func TestSearchPlayerFilterPostgres(t *testing.T) {
+	ctx := context.Background()
+	dsn := startPostgres(t)
+	const scope = ""
+	resetPublicSchema(t, dsn)
+
+	// Seed: import an XG match via the legacy Database, migrate into Postgres.
+	dbPath := filepath.Join(t.TempDir(), "src.db")
+	d := database.NewDatabase()
+	if err := d.SetupDatabase(dbPath); err != nil {
+		t.Fatalf("SetupDatabase: %v", err)
+	}
+	xg := filepath.Join("..", "..", "..", "..", "testdata", "charlot1-charlot2_7p_2025-11-08-2305.xg")
+	if _, err := d.ImportXGMatch(xg); err != nil {
+		t.Fatalf("ImportXGMatch: %v", err)
+	}
+	d.Close()
+
+	src, err := sqlite.Open(ctx, dbPath, nil)
+	if err != nil {
+		t.Fatalf("sqlite.Open: %v", err)
+	}
+	defer src.Close()
+	dst, err := pg.Open(ctx, dsn, nil)
+	if err != nil {
+		t.Fatalf("pg.Open: %v", err)
+	}
+	defer dst.Close()
+	if _, err := migrate.Run(ctx, src, dst, scope, migrate.Options{}); err != nil {
+		t.Fatalf("migrate.Run: %v", err)
+	}
+
+	total := findPlayer(t, dst, scope, domain.SearchFilters{})
+	if total == 0 {
+		t.Fatal("no positions migrated")
+	}
+
+	// Exact name (the fixture's players are charlot1 / charlot2).
+	if n := findPlayer(t, dst, scope, domain.SearchFilters{PlayerFilter: "charlot1"}); n == 0 {
+		t.Errorf("PlayerFilter=charlot1 returned 0, expected the match's positions")
+	}
+	// ILIKE is case-insensitive.
+	if n := findPlayer(t, dst, scope, domain.SearchFilters{PlayerFilter: "CHARLOT1"}); n == 0 {
+		t.Errorf("PlayerFilter=CHARLOT1 (uppercase) returned 0; ILIKE should be case-insensitive")
+	}
+	// A name in no match returns nothing.
+	if n := findPlayer(t, dst, scope, domain.SearchFilters{PlayerFilter: "ZZ_NoSuchPlayer_ZZ"}); n != 0 {
+		t.Errorf("unknown player returned %d, want 0", n)
+	}
+}

--- a/pkg/blunderdb/storage/postgres/search_postgres.go
+++ b/pkg/blunderdb/storage/postgres/search_postgres.go
@@ -84,6 +84,18 @@ func (s *searchStore) find(ctx context.Context, tenant int64, f domain.SearchFil
 		}
 	}
 
+	// Player filter: positions occurring in any match where the named player sat
+	// at either seat. ILIKE gives case-insensitive exact matching (Postgres LIKE
+	// is case-sensitive, unlike SQLite's).
+	if f.PlayerFilter != "" {
+		where.WriteString(
+			" AND p.id IN (SELECT mv.position_id FROM move mv" +
+				" JOIN game g ON mv.game_id = g.id" +
+				" JOIN match mt ON g.match_id = mt.id" +
+				" WHERE mt.player1_name ILIKE ? OR mt.player2_name ILIKE ?)")
+		args = append(args, f.PlayerFilter, f.PlayerFilter)
+	}
+
 	if f.RestrictToPositionIDs != "" {
 		var ids []int64
 		for _, idStr := range strings.Split(f.RestrictToPositionIDs, ",") {

--- a/pkg/blunderdb/storage/sqlite/search_sqlite.go
+++ b/pkg/blunderdb/storage/sqlite/search_sqlite.go
@@ -82,6 +82,18 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 		}
 	}
 
+	// Player filter: keep positions that occur in any match where the named
+	// player sat at either seat. LIKE (no wildcards) gives case-insensitive
+	// exact matching for ASCII names, mirroring the match-id subquery shape.
+	if f.PlayerFilter != "" {
+		where.WriteString(
+			" AND p.id IN (SELECT mv.position_id FROM move mv" +
+				" JOIN game g ON mv.game_id = g.id" +
+				" JOIN match mt ON g.match_id = mt.id" +
+				" WHERE mt.player1_name LIKE ? OR mt.player2_name LIKE ?)")
+		args = append(args, f.PlayerFilter, f.PlayerFilter)
+	}
+
 	if f.RestrictToPositionIDs != "" {
 		var ids []int64
 		for _, idStr := range strings.Split(f.RestrictToPositionIDs, ",") {


### PR DESCRIPTION
## Why

You could filter positions by match/tournament id, but not by **who played** — the single most-requested missing search filter (self-study: "all my decisions"; opponent prep: "everything X played").

## What

`pl"Name"` (command line `s pl"Alice"`, or a new **Player** field in the search panel's *Other* group) keeps positions occurring in any match where the named player sat at **either** seat. Case-insensitive.

- **Backend** `SearchFilters.PlayerFilter` → position→move→game→match subquery on `player1_name`/`player2_name`. `LIKE` (SQLite) / `ILIKE` (Postgres). Tested on **both** dialects.
- **Frontend**: parsed on the raw command (names with spaces survive the split), threaded through both `s`/`ss` call sites + the saved-search re-executor + the SearchPanel UI. i18n label + hint in all 9 locales.
- **Collision guard**: `pl"…"` starts with `p` but is **not** a pipcount — every `startsWith('p')` pickup now excludes `pl`. Covered by tests (round-trip, `pl`-vs-pipcount, spaced names, empty-token strip).
- **Docs**: `cmd_mode.rst` filter table + translations in all languages.

## Verification
Go database+sqlite + postgres-tagged player test; frontend suite **504**; lint, `vite build`, i18n parity, EN/JA doc builds — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)