### PR TITLE
refactor(stats): delegate Database stats methods to the storage backend

### DIFF
--- a/pkg/blunderdb/database/db_stats.go
+++ b/pkg/blunderdb/database/db_stats.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"math"
@@ -15,7 +16,16 @@ type StatsDateRange struct {
 
 // GetStatsDateRange returns the minimum and maximum match dates present in the
 // database. Both fields are empty when no matches with a date exist.
+// GetStatsDateRange delegates to the storage StatsStore. legacyGetStatsDateRange
+// keeps the original SQL as the parity-test reference.
 func (d *Database) GetStatsDateRange() StatsDateRange {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	r, _ := d.store.Stats().DateRange(context.Background(), "")
+	return fromStorageDateRange(r)
+}
+
+func legacyGetStatsDateRange(d *Database) StatsDateRange {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	if d.db == nil {
@@ -237,7 +247,20 @@ func buildStatsWhereClause(filter StatsFilter) (whereSQL string, args []any) {
 }
 
 // ComputeStats aggregates performance metrics for the given filter.
+// ComputeStats delegates to the storage StatsStore (the single production
+// implementation, shared with the headless server). legacyComputeStats keeps
+// the original SQL as the parity-test reference.
 func (d *Database) ComputeStats(filter StatsFilter) (*StatsResult, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	r, err := d.store.Stats().Compute(context.Background(), "", toStorageStatsFilter(filter))
+	if err != nil {
+		return nil, err
+	}
+	return fromStorageStatsResult(r), nil
+}
+
+func legacyComputeStats(d *Database, filter StatsFilter) (*StatsResult, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -702,7 +725,14 @@ func scanPositionIDs(rows interface {
 // panel into a deduplicated list of position IDs. The StatsFilter is always
 // applied so that the IDs correspond exactly to what is displayed in the panel
 // (invariant: "ce qu'on clique = ce qu'on voit").
+// GetPositionIDsByStatsSelection delegates to the storage StatsStore.
 func (d *Database) GetPositionIDsByStatsSelection(filter StatsFilter, sel SelectionSpec) ([]int64, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.store.Stats().PositionIDsBySelection(context.Background(), "", toStorageStatsFilter(filter), toStorageSelectionSpec(sel))
+}
+
+func legacyGetPositionIDsByStatsSelection(d *Database, filter StatsFilter, sel SelectionSpec) ([]int64, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -729,7 +759,14 @@ func (d *Database) GetPositionIDsByStatsSelection(filter StatsFilter, sel Select
 // GetPositionIDsByTournament returns all position IDs belonging to the given
 // tournament, regardless of any stats filter. Used when the user explicitly
 // reopens a tournament (Open tournament action).
+// GetPositionIDsByTournament delegates to the storage StatsStore.
 func (d *Database) GetPositionIDsByTournament(tournamentID int64) ([]int64, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.store.Stats().PositionIDsByTournament(context.Background(), "", tournamentID)
+}
+
+func legacyGetPositionIDsByTournament(d *Database, tournamentID int64) ([]int64, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -748,7 +785,14 @@ func (d *Database) GetPositionIDsByTournament(tournamentID int64) ([]int64, erro
 
 // GetPositionIDsByMatch returns all position IDs belonging to the given match,
 // regardless of any stats filter. Used when the user explicitly reopens a match.
+// GetPositionIDsByMatch delegates to the storage StatsStore.
 func (d *Database) GetPositionIDsByMatch(matchID int64) ([]int64, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.store.Stats().PositionIDsByMatch(context.Background(), "", matchID)
+}
+
+func legacyGetPositionIDsByMatch(d *Database, matchID int64) ([]int64, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -774,7 +818,18 @@ type PlayerFrequency struct {
 // GetAllPlayerNames returns all player names found in the match table, ranked by
 // the total number of matches (player1 + player2 appearances) descending.
 // Names that are equal in frequency are sorted alphabetically.
+// GetAllPlayerNames delegates to the storage StatsStore.
 func (d *Database) GetAllPlayerNames() ([]PlayerFrequency, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	p, err := d.store.Stats().PlayerNames(context.Background(), "")
+	if err != nil {
+		return nil, err
+	}
+	return fromStoragePlayerFreq(p), nil
+}
+
+func legacyGetAllPlayerNames(d *Database) ([]PlayerFrequency, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
@@ -1023,7 +1078,20 @@ type MatchDetailStats struct {
 }
 
 // GetMatchDetailStats computes per-player statistics for the given match.
+// GetMatchDetailStats delegates to the storage StatsStore. legacyGetMatchDetailStats
+// keeps the original SQL as the parity-test reference (pinned against eXtreme
+// Gammon reference values in TestStatsParity).
 func (d *Database) GetMatchDetailStats(matchID int64) (*MatchDetailStats, error) {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	m, err := d.store.Stats().MatchDetail(context.Background(), "", matchID)
+	if err != nil {
+		return nil, err
+	}
+	return fromStorageMatchDetail(m), nil
+}
+
+func legacyGetMatchDetailStats(d *Database, matchID int64) (*MatchDetailStats, error) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 

--- a/pkg/blunderdb/database/db_stats_drilldown_test.go
+++ b/pkg/blunderdb/database/db_stats_drilldown_test.go
@@ -325,6 +325,15 @@ func TestDrilldown_TournamentShortcut(t *testing.T) {
 	if len(all) != 4 {
 		t.Errorf("tournament shortcut should return 4 positions regardless of filter, got %d", len(all))
 	}
+
+	// Parity: the delegating method (storage) must match the legacy reference.
+	legacyAll, err := legacyGetPositionIDsByTournament(db, tid)
+	if err != nil {
+		t.Fatalf("legacyGetPositionIDsByTournament: %v", err)
+	}
+	if len(legacyAll) != len(all) {
+		t.Errorf("tournament drilldown parity: legacy=%d storage=%d", len(legacyAll), len(all))
+	}
 }
 
 // TestDrilldown_MatchShortcut verifies that GetPositionIDsByMatch ignores any

--- a/pkg/blunderdb/database/stats_convert.go
+++ b/pkg/blunderdb/database/stats_convert.go
@@ -1,0 +1,75 @@
+package database
+
+import (
+	"encoding/json"
+
+	"github.com/kevung/blunderdb/pkg/blunderdb/storage"
+)
+
+// stats_convert.go bridges the database.* and storage.* stats DTOs so the
+// Database stats methods can delegate to the storage.StatsStore (the single
+// production implementation, shared with the headless server) while keeping
+// their long-standing database.* return types — so the Wails bindings and the
+// frontend see no change.
+//
+// The two DTO families are field-identical and share the same json tags (and,
+// where untagged, the same field names) — a property the stats parity tests pin
+// byte-for-byte. Converting through a JSON round-trip is therefore exact *by
+// construction*: it cannot silently mis-map a field the way hand-written
+// assignments could, and a future divergence between the two type sets would
+// surface as a parity-test failure. Stats are computed on demand, never on a
+// hot path, so the marshal/unmarshal cost is irrelevant.
+
+func jsonConvert(src, dst any) {
+	b, _ := json.Marshal(src)
+	_ = json.Unmarshal(b, dst)
+}
+
+func toStorageStatsFilter(f StatsFilter) storage.StatsFilter {
+	var out storage.StatsFilter
+	jsonConvert(f, &out)
+	return out
+}
+
+func toStorageSelectionSpec(s SelectionSpec) storage.SelectionSpec {
+	var out storage.SelectionSpec
+	jsonConvert(s, &out)
+	return out
+}
+
+func fromStorageStatsResult(r *storage.StatsResult) *StatsResult {
+	if r == nil {
+		return nil
+	}
+	var out StatsResult
+	jsonConvert(r, &out)
+	return &out
+}
+
+func fromStorageDateRange(r storage.StatsDateRange) StatsDateRange {
+	var out StatsDateRange
+	jsonConvert(r, &out)
+	return out
+}
+
+func fromStorageMatchDetail(m *storage.MatchDetailStats) *MatchDetailStats {
+	if m == nil {
+		return nil
+	}
+	var out MatchDetailStats
+	jsonConvert(m, &out)
+	return &out
+}
+
+func fromStoragePlayerFreq(p []storage.PlayerFrequency) []PlayerFrequency {
+	if p == nil {
+		return nil
+	}
+	out := make([]PlayerFrequency, 0, len(p))
+	for _, x := range p {
+		var y PlayerFrequency
+		jsonConvert(x, &y)
+		out = append(out, y)
+	}
+	return out
+}

--- a/pkg/blunderdb/database/stats_storage_parity_test.go
+++ b/pkg/blunderdb/database/stats_storage_parity_test.go
@@ -61,30 +61,32 @@ func TestStatsStorageParity(t *testing.T) {
 				t.Fatalf("select match id: %v", err)
 			}
 
-			// 2. Legacy results.
-			legacyDR := d.GetStatsDateRange()
-			legacyAll, err := d.ComputeStats(StatsFilter{DecisionType: -1})
+			// 2. Legacy results. These call the legacy* reference implementations
+			// directly (the production Database methods now delegate to storage, so
+			// calling them here would compare storage against itself).
+			legacyDR := legacyGetStatsDateRange(d)
+			legacyAll, err := legacyComputeStats(d, StatsFilter{DecisionType: -1})
 			if err != nil {
 				t.Fatalf("legacy ComputeStats: %v", err)
 			}
-			legacyChecker, err := d.ComputeStats(StatsFilter{DecisionType: 0})
+			legacyChecker, err := legacyComputeStats(d, StatsFilter{DecisionType: 0})
 			if err != nil {
 				t.Fatalf("legacy ComputeStats(checker): %v", err)
 			}
-			legacyPlayers, err := d.GetAllPlayerNames()
+			legacyPlayers, err := legacyGetAllPlayerNames(d)
 			if err != nil {
 				t.Fatalf("legacy GetAllPlayerNames: %v", err)
 			}
-			legacyMatchIDs, err := d.GetPositionIDsByMatch(matchID)
+			legacyMatchIDs, err := legacyGetPositionIDsByMatch(d, matchID)
 			if err != nil {
 				t.Fatalf("legacy GetPositionIDsByMatch: %v", err)
 			}
-			legacySel, err := d.GetPositionIDsByStatsSelection(
+			legacySel, err := legacyGetPositionIDsByStatsSelection(d,
 				StatsFilter{DecisionType: -1}, SelectionSpec{Kind: "checker", OnlyWithError: true})
 			if err != nil {
 				t.Fatalf("legacy GetPositionIDsByStatsSelection: %v", err)
 			}
-			legacyDetail, err := d.GetMatchDetailStats(matchID)
+			legacyDetail, err := legacyGetMatchDetailStats(d, matchID)
 			if err != nil {
 				t.Fatalf("legacy GetMatchDetailStats: %v", err)
 			}


### PR DESCRIPTION
## Why

`db_stats.go` reimplemented the same stats SQL that `storage/{sqlite,postgres}` already run — the **third copy** of the aggregation logic, and the source of the triple-maintenance flagged in past stats fixes (e.g. the close-cube semantics had to be patched in 3 places).

## What

The 7 `Database` stats methods now **delegate to `d.store.Stats()`** (the single production implementation, shared with the headless server), keeping their `database.*` return types so the Wails bindings and frontend are unchanged.

- **Conversion** (`stats_convert.go`): JSON round-trip between the field-identical `database.*` / `storage.*` DTOs — exact by construction (the shared json tags are what the parity tests pin), no hand-mapping to get wrong.
- **Legacy SQL preserved** as lowercase `legacy*` reference functions (test-only callers).

## Guards (all rewired to keep biting)

- `TestStatsStorageParity` → compares `legacy*` reference vs **storage** (calling the now-delegating methods would compare storage to itself).
- `TestStatsParity` → still validates `GetMatchDetailStats` (now storage) against **eXtreme Gammon reference numbers**.
- drilldown tournament test → adds a legacy-vs-storage parity assertion.
- PostgreSQL parity → now cross-checks **SQLite-storage vs Postgres-storage**.

`go vet` + `golangci-lint` clean (0 issues); full Go suite + postgres-tagged parity green. JSON wire contract unchanged → frontend unaffected.

## Scope note

`populateMatchStats`/`populateTournamentStats` (match/tournament PR badges) stay in production — no storage equivalent yet. Physically moving the `legacy*` functions to a `_test.go` file (to drop the SQL from the production binary) is an optional follow-up; they're already unexported and lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)