### PR TITLE
test(fuzz): fuzz harnesses for untrusted-input decoders

### DIFF
--- a/pkg/blunderdb/domain/xgid_fuzz_test.go
+++ b/pkg/blunderdb/domain/xgid_fuzz_test.go
@@ -1,0 +1,39 @@
+package domain
+
+import (
+	"strings"
+	"testing"
+)
+
+// FuzzDecodeXGID exercises the XGID parser against arbitrary input. XGIDs come
+// from untrusted sources (clipboard paste, file/HTTP import), so the contract is
+// strict: DecodeXGID must NEVER panic, whatever bytes it is handed. When it does
+// return a position without error, the decoded board must round-trip back into a
+// well-formed 26-char board string via EncodeXGIDBoard.
+func FuzzDecodeXGID(f *testing.F) {
+	seeds := []string{
+		"",
+		"XGID=",
+		"XGID=a--aB-BBA--acDa-Ab-db---BA:0:0:1:64:2:0:0:13:10",
+		"XGID=bA----D-C---dE---d-e----B-:0:0:1:00:0:0:3:0:10",
+		"XGID=---BBaB-BbA-bC-b--BdAca---:0:0:1:00:0:5:0:9:10",
+		"a--aB-BBA--acDa-Ab-db---BA:0:0:1:64:2:0:0:13:10",
+		"XGID=:::::::::",
+		"XGID=" + strings.Repeat("Z", 26) + ":0:0:1:00:0:0:0:0:10",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, xgid string) {
+		pos, err := DecodeXGID(xgid)
+		if err != nil {
+			return
+		}
+		board := EncodeXGIDBoard(&pos)
+		if len(board) != 26 {
+			t.Fatalf("DecodeXGID accepted %q but EncodeXGIDBoard produced a %d-char board (want 26): %q",
+				xgid, len(board), board)
+		}
+	})
+}

--- a/pkg/blunderdb/engine/codec_fuzz_test.go
+++ b/pkg/blunderdb/engine/codec_fuzz_test.go
@@ -1,0 +1,57 @@
+package engine
+
+import (
+	"testing"
+)
+
+// FuzzDecodeBoardCompact exercises the compact-board decoder. The compact state
+// string is read back from the SQLite/Postgres `position.state` column; a
+// corrupt or hand-edited row must decode without panicking. When the input is
+// itself the output of EncodeBoardCompact, decoding must round-trip exactly.
+func FuzzDecodeBoardCompact(f *testing.F) {
+	seeds := []string{
+		"",
+		"[]",
+		"[0]",
+		"null",
+		"not json",
+		"[1,2,3]",
+		"[0,0,0,0,0,0,2,0,0,0,0,-5,0,-3,0,0,0,5,-5,0,0,0,3,0,5,0,0,0]",
+		"[999999999999,-999999999999]",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, s string) {
+		b := DecodeBoardCompact(s)
+		// Re-encoding a decoded board and decoding again must be stable: the
+		// codec is the storage round-trip, so it has to be idempotent.
+		again := DecodeBoardCompact(EncodeBoardCompact(b))
+		if again != b {
+			t.Fatalf("DecodeBoardCompact not idempotent for %q:\n first=%+v\nsecond=%+v", s, b, again)
+		}
+	})
+}
+
+// FuzzDecodeAnalysisFromStorage exercises the analysis blob decoder against
+// arbitrary bytes. The blob is read from the `analysis.data` column (raw JSON or
+// zlib-compressed); the auto-detection path must never panic on garbage bytes,
+// only return an error.
+func FuzzDecodeAnalysisFromStorage(f *testing.F) {
+	// A valid raw-JSON blob (first byte '{' → returned as-is).
+	f.Add([]byte(`{}`))
+	f.Add([]byte(`{"player1WinRate":0.5}`))
+	// A valid zlib-compressed blob.
+	if c, err := CompressAnalysisData([]byte(`{"player1WinRate":0.5}`)); err == nil {
+		f.Add(c)
+	}
+	f.Add([]byte(nil))
+	f.Add([]byte("not json, not zlib"))
+	f.Add([]byte{0x78, 0x9c, 0x00}) // truncated zlib header
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Contract: never panics. Both error and success are acceptable.
+		_, _ = DecodeAnalysisFromStorage(data)
+	})
+}

--- a/pkg/blunderdb/parser/parser_fuzz_test.go
+++ b/pkg/blunderdb/parser/parser_fuzz_test.go
@@ -1,0 +1,53 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kevung/blunderdb/pkg/blunderdb/domain"
+)
+
+// FuzzParsePosition feeds arbitrary text into the clipboard/file position
+// parser. The text comes straight from user paste and imported files, so the
+// parser must never panic — it may only return an error. Its own doc comment
+// promises "It never panics"; this guards that promise across the regex-heavy
+// language-detection and decode paths.
+func FuzzParsePosition(f *testing.F) {
+	seeds := []string{
+		"",
+		"   ",
+		"XGID=bA----D-C---dE---d-e----B-:0:0:1:00:0:0:3:0:10",
+		"XGID=bA----D-C---dE---d-e----B-:0:0:1:00:0:0:3:0:10\n\n" +
+			"X:Joueur 1   O:Joueur 2\nLe score est X:0 O:0. Partie illimitée",
+		"Analysis:\nChecker Move Analysis:\nfoo",
+		"Analysis:\nDoubling Cube Analysis:\nbar",
+		"Spieler Gegner Dopplerwürfel",
+		"プレーヤー 対戦相手 キューブ",
+		"not an xgid at all, just prose, 3.14, 1,5",
+	}
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, text string) {
+		res, err := ParsePosition(text)
+		if err != nil {
+			return
+		}
+		// A successful parse must yield a board that round-trips into a
+		// well-formed 26-char XGID board string; a corrupt decode surfaces here.
+		if board := domain.EncodeXGIDBoard(&res.Position); len(board) != 26 {
+			t.Fatalf("ParsePosition(%q) returned no error but a %d-char board: %q",
+				trunc(text), len(board), board)
+		}
+	})
+}
+
+// trunc keeps fuzz failure messages readable for large inputs.
+func trunc(s string) string {
+	s = strings.ReplaceAll(s, "\n", "\\n")
+	if len(s) > 80 {
+		return s[:80] + "…"
+	}
+	return s
+}


### PR DESCRIPTION
## Piste #3 — Robustesse des parseurs d'import

Adds fuzz coverage for the in-repo decoders that ingest untrusted input (clipboard paste, file/HTTP import, hand-editable DB rows):

- `FuzzDecodeXGID` — accepted XGIDs round-trip to a 26-char board
- `FuzzParsePosition` — successful parses yield a well-formed board
- `FuzzDecodeBoardCompact` — the storage codec is idempotent
- `FuzzDecodeAnalysisFromStorage` — zlib/raw auto-detect tolerates any bytes

Seed corpora run as ordinary subtests under `go test`, so the existing CI `go test -race ./...` exercises them with no workflow change. ~1M+ execs/target locally found **no crashes** — the parsers are already robust; this locks that in against future drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)