### PR TITLE
refactor(search): extract parseSearchCommand from SearchPanel

### DIFF
--- a/frontend/src/__tests__/searchFilterService.test.js
+++ b/frontend/src/__tests__/searchFilterService.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect, vi } from 'vitest';
-import { buildFilterTokens, buildSearchCommand, parseFilterTokens, filterTokenHint } from '../services/searchFilterService.js';
+import { buildFilterTokens, buildSearchCommand, parseFilterTokens, parseSearchCommand, filterTokenHint } from '../services/searchFilterService.js';
 
 // buildFilterTokens/buildSearchCommand are pure (no Wails imports), but the
 // round-trip block below imports commandProcessor's parseFilters, which pulls in
@@ -407,5 +407,82 @@ describe('Player filter token', () => {
 
     test('buildSearchCommand drops an empty pl"" token', () => {
         expect(buildSearchCommand(['cube', 'pl""'])).toBe('s cube');
+    });
+});
+
+describe('parseSearchCommand — restore path (verbatim from executeSearch)', () => {
+    test('bare "s" yields no filters and all flags off', () => {
+        const f = parseSearchCommand('s');
+        expect(f.cmdFilters).toEqual([]);
+        expect(f.nc).toBe(false);
+        expect(f.dt).toBe(false);
+        expect(f.dr).toBe(false);
+        expect(f.mp).toBe(false);
+        expect(f.pc).toBeUndefined();
+        expect(f.matchIDs).toBe('');
+        expect(f.tournamentIDs).toBe('');
+    });
+
+    test('flag tokens set their booleans', () => {
+        const f = parseSearchCommand('s cube score nc d M');
+        expect(f.ic).toBe(true);
+        expect(f.is).toBe(true);
+        expect(f.nc).toBe(true);
+        expect(f.dt).toBe(true);
+        expect(f.mp).toBe(true);
+    });
+
+    test('range tokens are captured for both players', () => {
+        const f = parseSearchCommand('s p>5 w<70 e10,20 W>30 P12');
+        expect(f.pc).toBe('p>5');
+        expect(f.wr).toBe('w<70');
+        expect(f.eq).toBe('e10,20');
+        expect(f.p2wr).toBe('W>30');
+        expect(f.p1apc).toBe('P12');
+    });
+
+    test('single-value checker tokens expand to a min,max pair', () => {
+        expect(parseSearchCommand('s o5').p1co).toBe('o5,5');
+        expect(parseSearchCommand('s K3').p2bc).toBe('K3,3');
+        expect(parseSearchCommand('s z2').p1cz).toBe('z2,2');
+    });
+
+    test('checker tokens already carrying a range or operator are left intact', () => {
+        expect(parseSearchCommand('s o3,4').p1co).toBe('o3,4');
+        expect(parseSearchCommand('s o>5').p1co).toBe('o>5');
+        expect(parseSearchCommand('s O<2').p2co).toBe('O<2');
+    });
+
+    test('quoted free-text filters survive embedded spaces', () => {
+        const f = parseSearchCommand('s m"Best move here" t"some text" pl"John Doe"');
+        expect(f.mpf).toBe('m"Best move here"');
+        expect(f.st).toBe('t"some text"');
+        expect(f.plf).toBe('pl"John Doe"');
+    });
+
+    test('pipcount p is not confused with the pl player filter', () => {
+        const f = parseSearchCommand('s pl"Jane" p<60');
+        expect(f.pc).toBe('p<60');
+        expect(f.plf).toBe('pl"Jane"');
+    });
+
+    test('match and tournament id tokens join on ";"', () => {
+        const f = parseSearchCommand('s ma1 ma2 ma7 tn3 tn4');
+        expect(f.matchIDs).toBe('1;2;7');
+        expect(f.tournamentIDs).toBe('3;4');
+    });
+
+    test('dice roll mode: D1 is first-only, D is both', () => {
+        expect(parseSearchCommand('s D1').drMode).toBe('first');
+        expect(parseSearchCommand('s D1').dr).toBe(true);
+        expect(parseSearchCommand('s D').drMode).toBe('both');
+        expect(parseSearchCommand('s D').dr).toBe(true);
+    });
+
+    test('backgammon b is distinguished from bo/bj outfield/jan blot tokens', () => {
+        const f = parseSearchCommand('s b>10 bo5 bj2');
+        expect(f.bg).toBe('b>10');
+        expect(f.p1ob).toBe('bo5');
+        expect(f.p1jb).toBe('bj2');
     });
 });

--- a/frontend/src/components/SearchPanel.svelte
+++ b/frontend/src/components/SearchPanel.svelte
@@ -6,7 +6,7 @@
     import { positionStore, positionsStore, positionBeforeFilterLibraryStore, positionIndexBeforeFilterLibraryStore } from '../stores/positionStore';
     import { searchExcludePositionStore, searchStructureModeStore, searchOfferedCubeStore, emptySearchBoardPosition, boardHasCheckers } from '../stores/searchExcludePositionStore';
     import { searchHistoryStore } from '../stores/searchHistoryStore';
-    import { buildFilterTokens, buildSearchCommand, parseFilterTokens, filterTokenHint } from '../services/searchFilterService.js';
+    import { buildFilterTokens, buildSearchCommand, parseFilterTokens, parseSearchCommand, filterTokenHint } from '../services/searchFilterService.js';
     import { filterLibraryStore } from '../stores/filterLibraryStore';
     import { searchParamsStore } from '../stores/searchParamsStore';
     import { databaseLoadedStore } from '../stores/databaseStore';
@@ -815,97 +815,46 @@
         restoreExcludeStructure(search.excludePosition);
         const command = search.command;
         if (command.startsWith('s ') || command === 's') {
-            const cmdFilters =
-                command === 's'
-                    ? []
-                    : command
-                          .slice(2)
-                          .trim()
-                          .split(' ')
-                          .map((f) => f.trim());
-            const ic = cmdFilters.includes('cube') || cmdFilters.includes('cu') || cmdFilters.includes('c') || cmdFilters.includes('cub');
-            const is = cmdFilters.includes('score') || cmdFilters.includes('sco') || cmdFilters.includes('sc') || cmdFilters.includes('s');
-            const nc = cmdFilters.includes('nc');
-            const dt = cmdFilters.includes('d');
-            const dr = cmdFilters.includes('D') || cmdFilters.includes('D1');
-            const drMode = cmdFilters.includes('D1') ? 'first' : 'both';
-            const mp = cmdFilters.includes('M');
-            const pc = cmdFilters.find((f) => typeof f === 'string' && !f.startsWith('pl') && (f.startsWith('p>') || f.startsWith('p<') || f.startsWith('p')));
-            const wr = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('w>') || f.startsWith('w<') || f.startsWith('w')));
-            const gr = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('g>') || f.startsWith('g<') || f.startsWith('g')));
-            const bg = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('b>') || f.startsWith('b<') || (f.startsWith('b') && !f.startsWith('bo'))) && !f.startsWith('bj'));
-            const p2wr = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('W>') || f.startsWith('W<') || f.startsWith('W')));
-            const p2gr = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('G>') || f.startsWith('G<') || f.startsWith('G')));
-            const p2bg = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('B>') || f.startsWith('B<') || (f.startsWith('B') && !f.startsWith('BO'))) && !f.startsWith('BJ'));
-            let p1co = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('o>') || f.startsWith('o<') || f.startsWith('o')));
-            if (p1co && !p1co.includes(',') && !p1co.includes('>') && !p1co.includes('<')) p1co = `${p1co},${p1co.slice(1)}`;
-            let p2co = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('O>') || f.startsWith('O<') || f.startsWith('O')));
-            if (p2co && !p2co.includes(',') && !p2co.includes('>') && !p2co.includes('<')) p2co = `${p2co},${p2co.slice(1)}`;
-            let p1bc = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('k>') || f.startsWith('k<') || f.startsWith('k')));
-            if (p1bc && !p1bc.includes(',') && !p1bc.includes('>') && !p1bc.includes('<')) p1bc = `${p1bc},${p1bc.slice(1)}`;
-            let p2bc = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('K>') || f.startsWith('K<') || f.startsWith('K')));
-            if (p2bc && !p2bc.includes(',') && !p2bc.includes('>') && !p2bc.includes('<')) p2bc = `${p2bc},${p2bc.slice(1)}`;
-            let p1cz = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('z>') || f.startsWith('z<') || f.startsWith('z')));
-            if (p1cz && !p1cz.includes(',') && !p1cz.includes('>') && !p1cz.includes('<')) p1cz = `${p1cz},${p1cz.slice(1)}`;
-            let p2cz = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('Z>') || f.startsWith('Z<') || f.startsWith('Z')));
-            if (p2cz && !p2cz.includes(',') && !p2cz.includes('>') && !p2cz.includes('<')) p2cz = `${p2cz},${p2cz.slice(1)}`;
-            const p1apc = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('P>') || f.startsWith('P<') || f.startsWith('P')));
-            const eq = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('e>') || f.startsWith('e<') || f.startsWith('e')));
-            const cd = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('T>') || f.startsWith('T<') || f.startsWith('T')));
-            const mpm = command.match(/m["'][^"']*["']/);
-            const mpf = mpm ? mpm[0] : '';
-            const stm = command.match(/t["'][^"']*["']/);
-            const st = stm ? stm[0] : '';
-            const plm = command.match(/pl["'][^"']*["']/);
-            const plf = plm ? plm[0] : '';
-            const p1ob = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('bo>') || f.startsWith('bo<') || f.startsWith('bo')));
-            const p2ob = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('BO>') || f.startsWith('BO<') || f.startsWith('BO')));
-            const p1jb = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('bj>') || f.startsWith('bj<') || f.startsWith('bj')));
-            const p2jb = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('BJ>') || f.startsWith('BJ<') || f.startsWith('BJ')));
-            const me = cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('E>') || f.startsWith('E<') || (f.startsWith('E') && /^E\d/.test(f))));
-            const maTokens = cmdFilters.filter((f) => typeof f === 'string' && /^ma\d/.test(f));
-            const matchIDs = maTokens.length > 0 ? maTokens.map((t) => t.slice(2)).join(';') : '';
-            const tnTokens = cmdFilters.filter((f) => typeof f === 'string' && /^tn\d/.test(f));
-            const tournamentIDs = tnTokens.length > 0 ? tnTokens.map((t) => t.slice(2)).join(';') : '';
+            const f = parseSearchCommand(command);
             onLoadPositionsByFilters(
-                cmdFilters,
-                ic,
-                is,
-                pc,
-                wr,
-                gr,
-                bg,
-                p2wr,
-                p2gr,
-                p2bg,
-                p1co,
-                p2co,
-                p1bc,
-                p2bc,
-                p1cz,
-                p2cz,
-                st,
-                p1apc,
-                eq,
-                dt,
-                dr,
-                mpf,
-                cd,
-                p1ob,
-                p2ob,
-                p1jb,
-                p2jb,
-                nc,
-                mp,
-                me,
+                f.cmdFilters,
+                f.ic,
+                f.is,
+                f.pc,
+                f.wr,
+                f.gr,
+                f.bg,
+                f.p2wr,
+                f.p2gr,
+                f.p2bg,
+                f.p1co,
+                f.p2co,
+                f.p1bc,
+                f.p2bc,
+                f.p1cz,
+                f.p2cz,
+                f.st,
+                f.p1apc,
+                f.eq,
+                f.dt,
+                f.dr,
+                f.mpf,
+                f.cd,
+                f.p1ob,
+                f.p2ob,
+                f.p1jb,
+                f.p2jb,
+                f.nc,
+                f.mp,
+                f.me,
                 command,
-                matchIDs,
-                tournamentIDs,
+                f.matchIDs,
+                f.tournamentIDs,
                 '',
                 false,
-                drMode,
+                f.drMode,
                 '',
-                plf
+                f.plf
             );
         }
     }

--- a/frontend/src/services/searchFilterService.js
+++ b/frontend/src/services/searchFilterService.js
@@ -337,6 +337,90 @@ export function parseFilterTokens(tokens) {
     };
 }
 
+/**
+ * Parse a persisted `s …` search command string back into the flat set of
+ * filter values SearchPanel hands to its `onLoadPositionsByFilters` callback
+ * when replaying a saved/library search.
+ *
+ * This is the inverse of buildSearchCommand for the *restore* path and is
+ * deliberately more complete than parseFilterTokens (which parses freshly built
+ * tokens at save time): it
+ *   - expands the shorthand single-value checker tokens (`o5` → `o5,5`) for the
+ *     two-sided range filters, and
+ *   - pulls the quoted free-text filters (`m"…"`, `t"…"`, `pl"…"`) straight from
+ *     the raw command so embedded spaces survive the whitespace split.
+ *
+ * Logic is lifted verbatim from SearchPanel.executeSearch; unifying it with
+ * parseFilterTokens is left as a follow-up because their predicates differ.
+ *
+ * @param {string} command - a command starting with `s ` (or the bare `s`).
+ * @returns {object} the parsed filter values, keyed by short name.
+ */
+export function parseSearchCommand(command) {
+    const cmdFilters =
+        command === 's'
+            ? []
+            : command
+                  .slice(2)
+                  .trim()
+                  .split(' ')
+                  .map((f) => f.trim());
+
+    // Single-value checker tokens (e.g. `o5`) restore as a `min,max` pair.
+    const expandPair = (tok) => {
+        if (tok && !tok.includes(',') && !tok.includes('>') && !tok.includes('<')) {
+            return `${tok},${tok.slice(1)}`;
+        }
+        return tok;
+    };
+
+    const matchTokens = (re) => cmdFilters.filter((f) => typeof f === 'string' && re.test(f));
+    const quoted = (prefix) => {
+        const m = command.match(new RegExp(`${prefix}["'][^"']*["']`));
+        return m ? m[0] : '';
+    };
+
+    const maTokens = matchTokens(/^ma\d/);
+    const tnTokens = matchTokens(/^tn\d/);
+
+    return {
+        cmdFilters,
+        ic: cmdFilters.includes('cube') || cmdFilters.includes('cu') || cmdFilters.includes('c') || cmdFilters.includes('cub'),
+        is: cmdFilters.includes('score') || cmdFilters.includes('sco') || cmdFilters.includes('sc') || cmdFilters.includes('s'),
+        nc: cmdFilters.includes('nc'),
+        dt: cmdFilters.includes('d'),
+        dr: cmdFilters.includes('D') || cmdFilters.includes('D1'),
+        drMode: cmdFilters.includes('D1') ? 'first' : 'both',
+        mp: cmdFilters.includes('M'),
+        pc: cmdFilters.find((f) => typeof f === 'string' && !f.startsWith('pl') && (f.startsWith('p>') || f.startsWith('p<') || f.startsWith('p'))),
+        wr: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('w>') || f.startsWith('w<') || f.startsWith('w'))),
+        gr: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('g>') || f.startsWith('g<') || f.startsWith('g'))),
+        bg: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('b>') || f.startsWith('b<') || (f.startsWith('b') && !f.startsWith('bo'))) && !f.startsWith('bj')),
+        p2wr: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('W>') || f.startsWith('W<') || f.startsWith('W'))),
+        p2gr: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('G>') || f.startsWith('G<') || f.startsWith('G'))),
+        p2bg: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('B>') || f.startsWith('B<') || (f.startsWith('B') && !f.startsWith('BO'))) && !f.startsWith('BJ')),
+        p1co: expandPair(cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('o>') || f.startsWith('o<') || f.startsWith('o')))),
+        p2co: expandPair(cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('O>') || f.startsWith('O<') || f.startsWith('O')))),
+        p1bc: expandPair(cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('k>') || f.startsWith('k<') || f.startsWith('k')))),
+        p2bc: expandPair(cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('K>') || f.startsWith('K<') || f.startsWith('K')))),
+        p1cz: expandPair(cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('z>') || f.startsWith('z<') || f.startsWith('z')))),
+        p2cz: expandPair(cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('Z>') || f.startsWith('Z<') || f.startsWith('Z')))),
+        p1apc: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('P>') || f.startsWith('P<') || f.startsWith('P'))),
+        eq: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('e>') || f.startsWith('e<') || f.startsWith('e'))),
+        cd: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('T>') || f.startsWith('T<') || f.startsWith('T'))),
+        mpf: quoted('m'),
+        st: quoted('t'),
+        plf: quoted('pl'),
+        p1ob: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('bo>') || f.startsWith('bo<') || f.startsWith('bo'))),
+        p2ob: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('BO>') || f.startsWith('BO<') || f.startsWith('BO'))),
+        p1jb: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('bj>') || f.startsWith('bj<') || f.startsWith('bj'))),
+        p2jb: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('BJ>') || f.startsWith('BJ<') || f.startsWith('BJ'))),
+        me: cmdFilters.find((f) => typeof f === 'string' && (f.startsWith('E>') || f.startsWith('E<') || (f.startsWith('E') && /^E\d/.test(f)))),
+        matchIDs: maTokens.length > 0 ? maTokens.map((t) => t.slice(2)).join(';') : '',
+        tournamentIDs: tnTokens.length > 0 ? tnTokens.map((t) => t.slice(2)).join(';') : ''
+    };
+}
+
 // Command-line token for each search filter, keyed by its canonical (English)
 // label — the same labels SearchPanel's filterGroups use. Single source of
 // truth for the in-UI token hint shown on hover; the prefixes mirror the


### PR DESCRIPTION
## Piste #2 — Découpage du monolithe `SearchPanel.svelte` (2649 lignes)

`executeSearch` carried ~90 lines of inline, **untested** string/regex parsing that turns a persisted `s …` command back into the flat values handed to `onLoadPositionsByFilters` (token scanning, the `o5`→`o5,5` shorthand expansion, the quoted `m"…"`/`t"…"`/`pl"…"` regex pulls).

Moved that block **verbatim** into a pure `parseSearchCommand(command)` in `searchFilterService.js`. `executeSearch` now calls it and spreads the result into the (unchanged) positional callback.

- **No behaviour change** — logic lifted character-for-character.
- Previously-buried restore-path parsing is now **unit-tested** (10 cases: flags, ranges, shorthand expansion, quoted text with spaces, ids, dice mode, `b` vs `bo`/`bj`).
- `parseFilterTokens` (the save-time parser) is intentionally left untouched; its predicates differ, so unifying the two parsers is a separate, riskier follow-up.

### Verification
✅ vitest **514 passed** (incl. the new `parseSearchCommand` suite) · ✅ eslint + prettier clean · ✅ frontend production build green.

> Note: re. la fragilité réactive Svelte 5 documentée (`tasks/ui-reactivity/`), j'ai délibérément évité la chirurgie template/composant de `SearchPanel` et limité l'extraction à de la logique pure, sûre et testable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)