### PR TITLE
docs(i18n): fix stale 0.27.0 changelog cells in 8 translations

### DIFF
--- a/doc/source/locale/de/LC_MESSAGES/index.po
+++ b/doc/source/locale/de/LC_MESSAGES/index.po
@@ -807,14 +807,12 @@ msgstr ""
 ":ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "1. Juni 2026"
+msgstr "13. Juni 2026"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/el/LC_MESSAGES/index.po
+++ b/doc/source/locale/el/LC_MESSAGES/index.po
@@ -804,14 +804,12 @@ msgstr ""
 ":ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "1 Ιουνίου 2026"
+msgstr "13 Ιουνίου 2026"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/en/LC_MESSAGES/index.po
+++ b/doc/source/locale/en/LC_MESSAGES/index.po
@@ -786,14 +786,12 @@ msgstr ""
 "cube value). See :ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "June 1, 2026"
+msgstr "June 13, 2026"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/es/LC_MESSAGES/index.po
+++ b/doc/source/locale/es/LC_MESSAGES/index.po
@@ -806,14 +806,12 @@ msgstr ""
 ":ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "1 de junio de 2026"
+msgstr "13 de junio de 2026"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/fi/LC_MESSAGES/index.po
+++ b/doc/source/locale/fi/LC_MESSAGES/index.po
@@ -795,14 +795,12 @@ msgstr ""
 "kuution arvo). Katso :ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "1.6.2026"
+msgstr "13.6.2026"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/it/LC_MESSAGES/index.po
+++ b/doc/source/locale/it/LC_MESSAGES/index.po
@@ -805,14 +805,12 @@ msgstr ""
 "videau). Vedere :ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "1 giugno 2026"
+msgstr "13 giugno 2026"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/ja/LC_MESSAGES/index.po
+++ b/doc/source/locale/ja/LC_MESSAGES/index.po
@@ -716,14 +716,12 @@ msgstr ""
 " のデコードを修正（Jacoby/Beaver フラグとキューブの値）。:ref:`configuration` を参照。"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "2026/06/01"
+msgstr "2026/06/13"
 
 #: ../../source/index.rst:1
 msgid ""

--- a/doc/source/locale/ru/LC_MESSAGES/index.po
+++ b/doc/source/locale/ru/LC_MESSAGES/index.po
@@ -798,14 +798,12 @@ msgstr ""
 ":ref:`configuration`."
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "0.27.0"
-msgstr "0.7.0"
+msgstr "0.27.0"
 
 #: ../../source/index.rst:1
-#, fuzzy
 msgid "13/06/2026"
-msgstr "01/06/2026"
+msgstr "13/06/2026"
 
 #: ../../source/index.rst:1
 msgid ""


### PR DESCRIPTION
## Suite #1 — Cellules fausses du changelog (`index.po`)

The 0.27.0 version-history row left **two fuzzy gettext cells** in every non-French catalog, so the translated changelog tables rendered wrong values:
- version shown as **`0.7.0`** instead of `0.27.0`;
- date shown with day **1** (e.g. *"June 1, 2026"*) instead of 13.

Fixes the `msgstr` of both cells and clears the fuzzy flag in all 8 locales (en, de, es, it, ru, el, fi, ja), keeping each language's established date format (only the day was stale — matches the correctly-translated 0.26.0 row above). Targeted edit: **16 changed lines, no catalog churn**.

Source of truth = `index.rst:150` (`0.27.0, 13/06/2026`). ✅ `sphinx-build -b html` green (en/ja exit 0; table now renders `0.27.0` and the 13 June date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)