### PR TITLE
fix(ingest): bounds-check BGF checker-move indices + scheduled fuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,58 @@
+name: Fuzz
+
+# Continuous fuzzing of the untrusted-input decoders/mappers. Runs on a weekly
+# schedule and on demand — never on push/PR, so it can't flake or block normal
+# CI. The seed corpora (incl. regression seeds) still run on every PR via the
+# `go test -race ./...` step in build.yml; this job is the open-ended search for
+# *new* crashes. A crash fails the job and uploads the minimised input.
+
+on:
+  schedule:
+    - cron: "0 4 * * 1" # Mondays 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      fuzztime:
+        description: "Duration per fuzz target (Go duration, e.g. 120s, 5m)"
+        required: false
+        default: "120s"
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { pkg: ./pkg/blunderdb/parser, target: FuzzParsePosition }
+          - { pkg: ./pkg/blunderdb/domain, target: FuzzDecodeXGID }
+          - { pkg: ./pkg/blunderdb/engine, target: FuzzDecodeBoardCompact }
+          - { pkg: ./pkg/blunderdb/engine, target: FuzzDecodeAnalysisFromStorage }
+          - { pkg: ./pkg/blunderdb/ingest, target: FuzzBGFApplyCheckerMove }
+    name: ${{ matrix.target }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup GoLang
+        uses: actions/setup-go@v5
+        with:
+          check-latest: true
+          go-version: 1.25.11
+          cache: true
+
+      - name: Fuzz ${{ matrix.target }}
+        run: |
+          go test -run '^$' -fuzz "^${{ matrix.target }}$" \
+            -fuzztime "${{ github.event.inputs.fuzztime || '120s' }}" \
+            ${{ matrix.pkg }}
+
+      - name: Upload crashing input
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: ${{ matrix.pkg }}/testdata/fuzz/${{ matrix.target }}/
+          if-no-files-found: ignore

--- a/pkg/blunderdb/ingest/bgfmap.go
+++ b/pkg/blunderdb/ingest/bgfmap.go
@@ -143,18 +143,26 @@ func bgfApplyCheckerMove(boardState *[28]int, moveData map[string]interface{}, p
 			break
 		}
 
+		// from/to come from an untrusted .bgf file. Compute the board indices
+		// and skip the whole sub-move if either falls outside the 28-point
+		// board, so a malformed file can't panic. Legal BGF values (0..25)
+		// always map in range, so valid imports are unaffected.
 		if player == -1 {
-			var fromIdx int
-			if from == 25 {
-				fromIdx = 24
-			} else {
+			fromIdx := 24
+			if from != 25 {
 				fromIdx = 24 - from
+			}
+			toIdx := 26 // bear-off slot used when to == 0
+			if to != 0 {
+				toIdx = 24 - to
+			}
+			if fromIdx < 0 || fromIdx >= 28 || toIdx < 0 || toIdx >= 28 {
+				continue
 			}
 			boardState[fromIdx]--
 			if to == 0 {
 				boardState[26]++
 			} else {
-				toIdx := 24 - to
 				if boardState[toIdx] < 0 {
 					boardState[25] += boardState[toIdx]
 					boardState[toIdx] = 0
@@ -162,17 +170,21 @@ func bgfApplyCheckerMove(boardState *[28]int, moveData map[string]interface{}, p
 				boardState[toIdx]++
 			}
 		} else {
-			var fromIdx int
-			if from == 25 {
-				fromIdx = 25
-			} else {
+			fromIdx := 25
+			if from != 25 {
 				fromIdx = from - 1
+			}
+			toIdx := 27 // bear-off slot used when to == 0
+			if to != 0 {
+				toIdx = to - 1
+			}
+			if fromIdx < 0 || fromIdx >= 28 || toIdx < 0 || toIdx >= 28 {
+				continue
 			}
 			boardState[fromIdx]++
 			if to == 0 {
 				boardState[27]--
 			} else {
-				toIdx := to - 1
 				if boardState[toIdx] > 0 {
 					boardState[24] += boardState[toIdx]
 					boardState[toIdx] = 0

--- a/pkg/blunderdb/ingest/bgfmap_fuzz_test.go
+++ b/pkg/blunderdb/ingest/bgfmap_fuzz_test.go
@@ -1,0 +1,34 @@
+package ingest
+
+import "testing"
+
+// FuzzBGFApplyCheckerMove exercises the BGF checker-move board update with
+// arbitrary from/to values. These come from parsed `.bgf` files (untrusted
+// input) and are mapped to 0-based board indices via `24-from` / `from-1`
+// arithmetic, then used to index a fixed [28]int board — so an out-of-range
+// from/to in a malformed file must be skipped, never panic.
+func FuzzBGFApplyCheckerMove(f *testing.F) {
+	// Seeds: a couple of legal moves plus the bar/off edge values.
+	f.Add(13, 7, 1)
+	f.Add(24, 18, -1)
+	f.Add(25, 0, 1)  // from bar, bear off
+	f.Add(25, 0, -1) // from bar, bear off
+	f.Add(99, -3, 1) // malformed (the historical panic)
+
+	f.Fuzz(func(t *testing.T, from, to, player int) {
+		// player is only meaningfully -1 or 1; map any other value onto those
+		// so the fuzzer spends its budget on the index arithmetic, not noise.
+		if player >= 0 {
+			player = 1
+		} else {
+			player = -1
+		}
+		board := [28]int{2, 0, 0, 0, 0, -5, 0, -3, 0, 0, 0, 5, -5, 0, 0, 0, 3, 0, 5, 0, 0, 0, 0, -2, 0, 0, 0, 0}
+		moveData := map[string]interface{}{
+			"from": []interface{}{float64(from)},
+			"to":   []interface{}{float64(to)},
+		}
+		// Contract: must not panic whatever from/to the parser produced.
+		bgfApplyCheckerMove(&board, moveData, player)
+	})
+}


### PR DESCRIPTION
## Étape #5 — Fuzz `ingest` + CI fuzz (a trouvé un vrai bug)

A new fuzz target **`FuzzBGFApplyCheckerMove`** crashed on its first run:
`index out of range [98] with length 28`. BGF `from`/`to` values are read **unbounded** from the parsed (untrusted) `.bgf` file, then mapped to board indices via `24-from` / `from-1` and used to index a fixed `[28]int` — so a malformed file with e.g. `from=99` **panicked the whole import**.

### Fix
Compute the source and target indices up front and **skip the sub-move when either falls outside the 28-point board**, before mutating. Legal BGF values (0..25) always map in range, so **valid imports are byte-for-byte unaffected** (existing ingest tests + `-race` stay green); only malformed input — which used to panic — is now skipped.

### CI fuzzing
New dedicated **`.github/workflows/fuzz.yml`**: weekly cron + manual dispatch, one job per fuzz target across the 5 existing targets, uploading the minimised crash input as an artifact. It **never runs on push/PR**, so it can't flake or block normal CI — the seed corpora (incl. this regression seed) still run on every PR via `go test -race ./...`.

### Verification
✅ fuzz 20s green post-fix · ✅ `go test -race ./pkg/blunderdb/ingest/` green · ✅ golangci-lint 0 issues · ✅ workflow YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)