### PR TITLE
fix(import): bounds-check BGF indices in the legacy GUI/CLI path

### DIFF
--- a/pkg/blunderdb/database/db_import_bgf.go
+++ b/pkg/blunderdb/database/db_import_bgf.go
@@ -792,15 +792,24 @@ func bgfApplyCheckerMove(boardState *[28]int, moveData map[string]interface{}, p
 			break // No more submoves
 		}
 
+		// from/to come from an untrusted .bgf file. Compute the board indices
+		// and skip the whole sub-move if either falls outside the 28-point
+		// board, so a malformed file can't panic. Legal BGF values (0..25)
+		// always map in range, so valid imports are unaffected.
 		if player == -1 {
 			// Green moves: Green's point N maps to board index (24-N)
 			// BGF board: index 0 = Green's 24-point, index 23 = Green's 1-point
 			// Green moves in decreasing direction (24→1→off)
-			var fromIdx int
-			if from == 25 {
-				fromIdx = 24 // Green's bar
-			} else {
+			fromIdx := 24 // Green's bar
+			if from != 25 {
 				fromIdx = 24 - from // Green's point N → board index (24-N)
+			}
+			toIdx := 26 // bear-off slot used when to == 0
+			if to != 0 {
+				toIdx = 24 - to // Green's point N → board index (24-N)
+			}
+			if fromIdx < 0 || fromIdx >= 28 || toIdx < 0 || toIdx >= 28 {
+				continue
 			}
 
 			// Remove checker from source
@@ -810,7 +819,6 @@ func bgfApplyCheckerMove(boardState *[28]int, moveData map[string]interface{}, p
 				// Bear off
 				boardState[26]++
 			} else {
-				toIdx := 24 - to // Green's point N → board index (24-N)
 				// Check for hit
 				if boardState[toIdx] < 0 {
 					// Hit Red checker - move it to Red's bar
@@ -823,11 +831,16 @@ func bgfApplyCheckerMove(boardState *[28]int, moveData map[string]interface{}, p
 			// Red moves: Red's point N maps to board index (N-1)
 			// Red's point N = Green's point (25-N) = board index 24-(25-N) = N-1
 			// Red moves in increasing direction (from Green's perspective)
-			var fromIdx int
-			if from == 25 {
-				fromIdx = 25 // Red's bar
-			} else {
+			fromIdx := 25 // Red's bar
+			if from != 25 {
 				fromIdx = from - 1 // Red's point N → board index (N-1)
+			}
+			toIdx := 27 // bear-off slot used when to == 0
+			if to != 0 {
+				toIdx = to - 1 // Red's point N → board index (N-1)
+			}
+			if fromIdx < 0 || fromIdx >= 28 || toIdx < 0 || toIdx >= 28 {
+				continue
 			}
 
 			// Remove checker from source (Red checkers are negative)
@@ -837,7 +850,6 @@ func bgfApplyCheckerMove(boardState *[28]int, moveData map[string]interface{}, p
 				// Bear off
 				boardState[27]--
 			} else {
-				toIdx := to - 1 // Red's point N → board index (N-1)
 				// Check for hit
 				if boardState[toIdx] > 0 {
 					// Hit Green checker - move it to Green's bar

--- a/pkg/blunderdb/database/db_import_bgf_fuzz_test.go
+++ b/pkg/blunderdb/database/db_import_bgf_fuzz_test.go
@@ -1,0 +1,30 @@
+package database
+
+import "testing"
+
+// FuzzBGFApplyCheckerMove exercises the legacy (GUI/CLI) BGF checker-move board
+// update with arbitrary from/to values. Like its ingest twin, these come from
+// parsed `.bgf` files (untrusted) and are mapped to board indices via
+// `24-from` / `from-1` then used to index a fixed [28]int — an out-of-range
+// from/to in a malformed file must be skipped, never panic.
+func FuzzBGFApplyCheckerMove(f *testing.F) {
+	f.Add(13, 7, 1)
+	f.Add(24, 18, -1)
+	f.Add(25, 0, 1)
+	f.Add(25, 0, -1)
+	f.Add(99, -3, 1) // malformed: historical index-out-of-range panic
+
+	f.Fuzz(func(t *testing.T, from, to, player int) {
+		if player >= 0 {
+			player = 1
+		} else {
+			player = -1
+		}
+		board := [28]int{2, 0, 0, 0, 0, -5, 0, -3, 0, 0, 0, 5, -5, 0, 0, 0, 3, 0, 5, 0, 0, 0, 0, -2, 0, 0, 0, 0}
+		moveData := map[string]interface{}{
+			"from": []interface{}{float64(from)},
+			"to":   []interface{}{float64(to)},
+		}
+		bgfApplyCheckerMove(&board, moveData, player)
+	})
+}


### PR DESCRIPTION
## Étape #4 — Parseurs d'import Go

Investigating the large import parsers revealed that `database/db_import_bgf.go` and `ingest/bgfmap.go` are **two parallel import implementations** (GUI/CLI use the former, the headless server the latter) — and the legacy one carries the **same out-of-range crash** fixed in #85.

`bgfApplyCheckerMove` maps untrusted BGF `from`/`to` to board indices (`24-from` / `from-1`) and indexes a fixed `[28]int`, so a malformed `.bgf` (e.g. `from=99`) **panics the whole `ImportBGFMatch`** in the primary GUI/CLI path.

### Fix
Identical guard to #85: compute both indices up front, skip the sub-move when either is outside the 28-point board, before mutating. Legal BGF values (0..25) always map in range → **valid imports unaffected** (full database test suite green). Locked with a `FuzzBGFApplyCheckerMove` twin (seed corpus runs on every PR via `go test -race ./...`; the weekly Fuzz job covers the ingest twin).

### Scope note
A cosmetic file-split of these 1600–1900-line files adds little; the real debt is the **db_import_* ↔ ingest duplication**. Fully unifying them (delegating the Database import path to `ingest`) is a larger, data-correctness-sensitive migration left as a **separate supervised effort** — this PR just kills the shared latent panic.

### Verification
✅ `go test ./pkg/blunderdb/database/` green · ✅ fuzz 15s green · ✅ vet + golangci-lint 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)