### PR TITLE
chore(bindings): regenerate wailsjs bindings for merged features

### DIFF
--- a/frontend/wailsjs/go/database/Database.d.ts
+++ b/frontend/wailsjs/go/database/Database.d.ts
@@ -113,8 +113,6 @@ export function GetMovesByGame(arg1:number):Promise<Array<domain.Move>>;
 
 export function GetNextAnkiCard(arg1:number):Promise<domain.AnkiReviewCard>;
 
-export function GetRandomAnkiCard(arg1:number,arg2:number):Promise<domain.AnkiReviewCard>;
-
 export function GetPositionCollections(arg1:number):Promise<Array<database.Collection>>;
 
 export function GetPositionIDsByMatch(arg1:number):Promise<Array<number>>;
@@ -124,6 +122,8 @@ export function GetPositionIDsByStatsSelection(arg1:database.StatsFilter,arg2:da
 export function GetPositionIDsByTournament(arg1:number):Promise<Array<number>>;
 
 export function GetPositionIndexMap():Promise<Record<number, number>>;
+
+export function GetRandomAnkiCard(arg1:number,arg2:number):Promise<domain.AnkiReviewCard>;
 
 export function GetStatsDateRange():Promise<database.StatsDateRange>;
 

--- a/frontend/wailsjs/go/database/Database.js
+++ b/frontend/wailsjs/go/database/Database.js
@@ -218,10 +218,6 @@ export function GetNextAnkiCard(arg1) {
   return window['go']['database']['Database']['GetNextAnkiCard'](arg1);
 }
 
-export function GetRandomAnkiCard(arg1, arg2) {
-  return window['go']['database']['Database']['GetRandomAnkiCard'](arg1, arg2);
-}
-
 export function GetPositionCollections(arg1) {
   return window['go']['database']['Database']['GetPositionCollections'](arg1);
 }
@@ -240,6 +236,10 @@ export function GetPositionIDsByTournament(arg1) {
 
 export function GetPositionIndexMap() {
   return window['go']['database']['Database']['GetPositionIndexMap']();
+}
+
+export function GetRandomAnkiCard(arg1, arg2) {
+  return window['go']['database']['Database']['GetRandomAnkiCard'](arg1, arg2);
 }
 
 export function GetStatsDateRange() {

--- a/frontend/wailsjs/go/models.ts
+++ b/frontend/wailsjs/go/models.ts
@@ -1122,6 +1122,7 @@ export namespace domain {
 	    moveErrorFilter: string;
 	    matchIDsFilter: string;
 	    tournamentIDsFilter: string;
+	    playerFilter: string;
 	    positionIDsFilter: string;
 	    restrictToPositionIDs: string;
 	
@@ -1166,6 +1167,7 @@ export namespace domain {
 	        this.moveErrorFilter = source["moveErrorFilter"];
 	        this.matchIDsFilter = source["matchIDsFilter"];
 	        this.tournamentIDsFilter = source["tournamentIDsFilter"];
+	        this.playerFilter = source["playerFilter"];
 	        this.positionIDsFilter = source["positionIDsFilter"];
 	        this.restrictToPositionIDs = source["restrictToPositionIDs"];
 	    }


### PR DESCRIPTION
Auto-generated Wails bindings had drifted from the bound backend: the `SearchFilter` model was missing the `playerFilter` field (pl'Name' player filter) and `GetRandomAnkiCard` (Anki cram mode) was out of the codegen's alphabetical order. Commits the regenerated bindings so the checked-in `.d.ts`/`.js`/`models.ts` match the current Database/domain types. Generated files only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)