### PR TITLE
refactor(match): data-drive the per-player match stats table

### DIFF
--- a/frontend/src/__tests__/matchTable.test.js
+++ b/frontend/src/__tests__/matchTable.test.js
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'vitest';
-import { compareValues, getSortValue, sortMatches, toDateInputValue, formatDate, formatDiceShort } from '../utils/matchTable.js';
+import { compareValues, getSortValue, sortMatches, toDateInputValue, formatDate, formatDiceShort, fmtPR, fmtEquityError, fmtMwcLoss, fmtErrorsBlunders, MATCH_STAT_ROWS } from '../utils/matchTable.js';
 
 describe('compareValues', () => {
     test('nulls sort last regardless of order', () => {
@@ -122,5 +122,79 @@ describe('formatDiceShort', () => {
         expect(formatDiceShort(null)).toBe('');
         expect(formatDiceShort([0, 0])).toBe('');
         expect(formatDiceShort(undefined)).toBe('');
+    });
+});
+
+describe('match stats cell formatters', () => {
+    test('fmtPR shows 2 decimals when there are decisions, em-dash otherwise', () => {
+        expect(fmtPR(5.456, 10)).toBe('5.46');
+        expect(fmtPR(0, 0)).toBe('—');
+        expect(fmtPR(3.1, 0)).toBe('—'); // no decisions → N/A regardless of value
+    });
+
+    test('fmtEquityError prefixes a minus and 3 decimals, em-dash at zero', () => {
+        expect(fmtEquityError(0.1234)).toBe('-0.123');
+        expect(fmtEquityError(0)).toBe('—');
+    });
+
+    test('fmtMwcLoss renders a negative percentage with 2 decimals, em-dash at zero', () => {
+        expect(fmtMwcLoss(0.0512)).toBe('-5.12%');
+        expect(fmtMwcLoss(0)).toBe('—');
+    });
+
+    test('fmtErrorsBlunders is "errors (blunders)"', () => {
+        expect(fmtErrorsBlunders(7, 2)).toBe('7 (2)');
+    });
+});
+
+describe('MATCH_STAT_ROWS', () => {
+    const sample = {
+        pr: 4.5,
+        pr_checker: 3.2,
+        pr_cube: 6.1,
+        total_decisions: 100,
+        checker_decisions: 80,
+        double_decisions: 12,
+        take_decisions: 8,
+        total_errors: 20,
+        total_blunders: 5,
+        total_equity_error: 1.234,
+        mwc_loss: 0.042,
+        checker_errors: 12,
+        checker_blunders: 3,
+        checker_equity_error: 0.8,
+        checker_mwc_loss: 0.03,
+        double_errors: 4,
+        double_blunders: 1,
+        double_equity_error: 0.3,
+        double_mwc_loss: 0.01,
+        take_errors: 4,
+        take_blunders: 1,
+        take_equity_error: 0.13,
+        take_mwc_loss: 0.011
+    };
+
+    test('every metric row has a label + fmt; sections have just a section key', () => {
+        for (const row of MATCH_STAT_ROWS) {
+            if (row.section) {
+                expect(typeof row.section).toBe('string');
+            } else {
+                expect(typeof row.label).toBe('string');
+                expect(typeof row.fmt).toBe('function');
+                expect(typeof row.fmt(sample)).toBe('string');
+            }
+        }
+    });
+
+    test('the four section headers are present in order', () => {
+        const sections = MATCH_STAT_ROWS.filter((r) => r.section).map((r) => r.section);
+        expect(sections).toEqual(['match.performanceRating', 'match.totalErrors', 'match.checkerPlay', 'match.cubePlay']);
+    });
+
+    test('overall PR row formats the sample correctly', () => {
+        const overall = MATCH_STAT_ROWS.find((r) => r.label === 'match.overallPr');
+        expect(overall.fmt(sample)).toBe('4.50');
+        expect(overall.valClass).toBe('pr-val');
+        expect(overall.bullet).toBe(true);
     });
 });

--- a/frontend/src/components/MatchPanel.svelte
+++ b/frontend/src/components/MatchPanel.svelte
@@ -1,6 +1,6 @@
 <script>
     import { logger } from '../utils/logger.js';
-    import { sortMatches, toDateInputValue, formatDate, formatDiceShort } from '../utils/matchTable.js';
+    import { sortMatches, toDateInputValue, formatDate, formatDiceShort, MATCH_STAT_ROWS } from '../utils/matchTable.js';
     import { onMount, onDestroy, untrack } from 'svelte';
     import { get } from 'svelte/store';
     import {
@@ -1072,116 +1072,17 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr class="stats-section-header">
-                                        <td colspan="3">{$t('match.performanceRating')}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.overallPr')}</td>
-                                        <td class="stats-val pr-val">{p1.total_decisions > 0 ? p1.pr.toFixed(2) : '—'}</td>
-                                        <td class="stats-val pr-val">{p2.total_decisions > 0 ? p2.pr.toFixed(2) : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.checkerPlayPr')}</td>
-                                        <td class="stats-val">{p1.checker_decisions > 0 ? p1.pr_checker.toFixed(2) : '—'}</td>
-                                        <td class="stats-val">{p2.checker_decisions > 0 ? p2.pr_checker.toFixed(2) : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.cubePlayPr')}</td>
-                                        <td class="stats-val">{p1.double_decisions + p1.take_decisions > 0 ? p1.pr_cube.toFixed(2) : '—'}</td>
-                                        <td class="stats-val">{p2.double_decisions + p2.take_decisions > 0 ? p2.pr_cube.toFixed(2) : '—'}</td>
-                                    </tr>
-
-                                    <tr class="stats-section-header">
-                                        <td colspan="3">{$t('match.totalErrors')}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.errorsBlunders')}</td>
-                                        <td class="stats-val">{p1.total_errors} ({p1.total_blunders})</td>
-                                        <td class="stats-val">{p2.total_errors} ({p2.total_blunders})</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.equityErrorEmg')}</td>
-                                        <td class="stats-val sub-val">{p1.total_equity_error > 0 ? '-' + p1.total_equity_error.toFixed(3) : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.total_equity_error > 0 ? '-' + p2.total_equity_error.toFixed(3) : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.mwcLoss')}</td>
-                                        <td class="stats-val sub-val">{p1.mwc_loss > 0 ? '-' + (p1.mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.mwc_loss > 0 ? '-' + (p2.mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.decisions')}</td>
-                                        <td class="stats-val sub-val">{p1.total_decisions}</td>
-                                        <td class="stats-val sub-val">{p2.total_decisions}</td>
-                                    </tr>
-
-                                    <tr class="stats-section-header">
-                                        <td colspan="3">{$t('match.checkerPlay')}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.checkerErrorsBlunders')}</td>
-                                        <td class="stats-val">{p1.checker_errors} ({p1.checker_blunders})</td>
-                                        <td class="stats-val">{p2.checker_errors} ({p2.checker_blunders})</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.equityErrorEmg')}</td>
-                                        <td class="stats-val sub-val">{p1.checker_equity_error > 0 ? '-' + p1.checker_equity_error.toFixed(3) : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.checker_equity_error > 0 ? '-' + p2.checker_equity_error.toFixed(3) : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.mwcLoss')}</td>
-                                        <td class="stats-val sub-val">{p1.checker_mwc_loss > 0 ? '-' + (p1.checker_mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.checker_mwc_loss > 0 ? '-' + (p2.checker_mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.unforcedMoves')}</td>
-                                        <td class="stats-val sub-val">{p1.checker_decisions}</td>
-                                        <td class="stats-val sub-val">{p2.checker_decisions}</td>
-                                    </tr>
-
-                                    <tr class="stats-section-header">
-                                        <td colspan="3">{$t('match.cubePlay')}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.doublesBlunders')}</td>
-                                        <td class="stats-val">{p1.double_errors} ({p1.double_blunders})</td>
-                                        <td class="stats-val">{p2.double_errors} ({p2.double_blunders})</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.equityErrorEmg')}</td>
-                                        <td class="stats-val sub-val">{p1.double_equity_error > 0 ? '-' + p1.double_equity_error.toFixed(3) : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.double_equity_error > 0 ? '-' + p2.double_equity_error.toFixed(3) : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.mwcLoss')}</td>
-                                        <td class="stats-val sub-val">{p1.double_mwc_loss > 0 ? '-' + (p1.double_mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.double_mwc_loss > 0 ? '-' + (p2.double_mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.cubeDecisions')}</td>
-                                        <td class="stats-val sub-val">{p1.double_decisions}</td>
-                                        <td class="stats-val sub-val">{p2.double_decisions}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label">• {$t('match.takesBlunders')}</td>
-                                        <td class="stats-val">{p1.take_errors} ({p1.take_blunders})</td>
-                                        <td class="stats-val">{p2.take_errors} ({p2.take_blunders})</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.equityErrorEmg')}</td>
-                                        <td class="stats-val sub-val">{p1.take_equity_error > 0 ? '-' + p1.take_equity_error.toFixed(3) : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.take_equity_error > 0 ? '-' + p2.take_equity_error.toFixed(3) : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.mwcLoss')}</td>
-                                        <td class="stats-val sub-val">{p1.take_mwc_loss > 0 ? '-' + (p1.take_mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                        <td class="stats-val sub-val">{p2.take_mwc_loss > 0 ? '-' + (p2.take_mwc_loss * 100).toFixed(2) + '%' : '—'}</td>
-                                    </tr>
-                                    <tr>
-                                        <td class="stats-label sub-label">{$t('match.takeDecisions')}</td>
-                                        <td class="stats-val sub-val">{p1.take_decisions}</td>
-                                        <td class="stats-val sub-val">{p2.take_decisions}</td>
-                                    </tr>
+                                    {#each MATCH_STAT_ROWS as row, i (i)}
+                                        {#if row.section}
+                                            <tr class="stats-section-header"><td colspan="3">{$t(row.section)}</td></tr>
+                                        {:else}
+                                            <tr>
+                                                <td class="stats-label{row.sub ? ' sub-label' : ''}">{row.bullet ? '• ' : ''}{$t(row.label)}</td>
+                                                <td class="stats-val{row.valClass ? ' ' + row.valClass : ''}{row.sub ? ' sub-val' : ''}">{row.fmt(p1)}</td>
+                                                <td class="stats-val{row.valClass ? ' ' + row.valClass : ''}{row.sub ? ' sub-val' : ''}">{row.fmt(p2)}</td>
+                                            </tr>
+                                        {/if}
+                                    {/each}
                                 </tbody>
                             </table>
                         {/if}

--- a/frontend/src/utils/matchTable.js
+++ b/frontend/src/utils/matchTable.js
@@ -81,3 +81,46 @@ export function formatDiceShort(dice) {
     if (!dice || (!dice[0] && !dice[1])) return '';
     return `${dice[0]}${dice[1]}`;
 }
+
+// --- Match-detail per-player stats table -------------------------------------
+
+// Cell formatters for the MatchPanel "stats" tab. A player's MatchPlayerDetailStats
+// maps to a displayed string; em-dash ("—") marks "not applicable / no data".
+export const fmtPR = (val, decisions) => (decisions > 0 ? val.toFixed(2) : '—');
+export const fmtEquityError = (v) => (v > 0 ? '-' + v.toFixed(3) : '—');
+export const fmtMwcLoss = (v) => (v > 0 ? '-' + (v * 100).toFixed(2) + '%' : '—');
+export const fmtErrorsBlunders = (errors, blunders) => `${errors} (${blunders})`;
+
+// MATCH_STAT_ROWS describes the per-player match stats table row by row. Each
+// entry is either a section header ({ section }) or a metric ({ label, fmt, … });
+// fmt maps one player's stats to its cell. Rendered by MatchPanel; labels are
+// i18n keys translated at render time. bullet = leading "•"; sub = indented
+// sub-metric; valClass = extra value-cell class.
+export const MATCH_STAT_ROWS = [
+    { section: 'match.performanceRating' },
+    { label: 'match.overallPr', bullet: true, valClass: 'pr-val', fmt: (p) => fmtPR(p.pr, p.total_decisions) },
+    { label: 'match.checkerPlayPr', bullet: true, fmt: (p) => fmtPR(p.pr_checker, p.checker_decisions) },
+    { label: 'match.cubePlayPr', bullet: true, fmt: (p) => fmtPR(p.pr_cube, p.double_decisions + p.take_decisions) },
+
+    { section: 'match.totalErrors' },
+    { label: 'match.errorsBlunders', bullet: true, fmt: (p) => fmtErrorsBlunders(p.total_errors, p.total_blunders) },
+    { label: 'match.equityErrorEmg', sub: true, fmt: (p) => fmtEquityError(p.total_equity_error) },
+    { label: 'match.mwcLoss', sub: true, fmt: (p) => fmtMwcLoss(p.mwc_loss) },
+    { label: 'match.decisions', sub: true, fmt: (p) => String(p.total_decisions) },
+
+    { section: 'match.checkerPlay' },
+    { label: 'match.checkerErrorsBlunders', bullet: true, fmt: (p) => fmtErrorsBlunders(p.checker_errors, p.checker_blunders) },
+    { label: 'match.equityErrorEmg', sub: true, fmt: (p) => fmtEquityError(p.checker_equity_error) },
+    { label: 'match.mwcLoss', sub: true, fmt: (p) => fmtMwcLoss(p.checker_mwc_loss) },
+    { label: 'match.unforcedMoves', sub: true, fmt: (p) => String(p.checker_decisions) },
+
+    { section: 'match.cubePlay' },
+    { label: 'match.doublesBlunders', bullet: true, fmt: (p) => fmtErrorsBlunders(p.double_errors, p.double_blunders) },
+    { label: 'match.equityErrorEmg', sub: true, fmt: (p) => fmtEquityError(p.double_equity_error) },
+    { label: 'match.mwcLoss', sub: true, fmt: (p) => fmtMwcLoss(p.double_mwc_loss) },
+    { label: 'match.cubeDecisions', sub: true, fmt: (p) => String(p.double_decisions) },
+    { label: 'match.takesBlunders', bullet: true, fmt: (p) => fmtErrorsBlunders(p.take_errors, p.take_blunders) },
+    { label: 'match.equityErrorEmg', sub: true, fmt: (p) => fmtEquityError(p.take_equity_error) },
+    { label: 'match.mwcLoss', sub: true, fmt: (p) => fmtMwcLoss(p.take_mwc_loss) },
+    { label: 'match.takeDecisions', sub: true, fmt: (p) => String(p.take_decisions) }
+];


### PR DESCRIPTION
## Suite — découpage `MatchPanel` (table de stats data-driven)

The "stats" tab hand-wrote ~110 lines of near-identical `<tr><td>{label}</td><td>{fmt(p1)}</td><td>{fmt(p2)}</td></tr>` rows — same formatting repeated per player and per section.

Describes the table as data in `utils/matchTable.js`:
- **`MATCH_STAT_ROWS`** — section headers + metric rows, each with an `fmt(player)` closure.
- shared cell formatters: `fmtPR` (with the N/A guard), `fmtEquityError`, `fmtMwcLoss`, `fmtErrorsBlunders`.

Rendered with a single `{#each}`. **tbody ~110 → ~13 lines**; the formatting logic is now pure and **unit-tested** instead of inlined in markup.

**No behaviour change intended** — same rows, labels, section order, CSS classes, formatting. New `matchTable` unit tests pin the formatters + row descriptors (section order, every metric row has label+fmt, overall-PR cell/class/bullet).

✅ vitest **527 passed** · eslint + prettier clean · production build green.

> ⚠️ **Held for GUI verification** before merge: please `wails dev` → open a match → **Stats** tab and confirm the table renders identically (the 4 sections — Performance Rating / Total Errors / Checker Play / Cube Play — with the right values, bullets, indentation and the PR column styling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)