### PR TITLE
refactor(ui): share the table sort-toggle logic across panels

### DIFF
--- a/frontend/src/__tests__/tableSort.test.js
+++ b/frontend/src/__tests__/tableSort.test.js
@@ -1,0 +1,26 @@
+import { describe, test, expect } from 'vitest';
+import { nextSort } from '../utils/tableSort.js';
+
+describe('nextSort', () => {
+    test('switching to a different column uses defaultDir (asc by default)', () => {
+        expect(nextSort(null, 'asc', 'date')).toEqual({ column: 'date', direction: 'asc' });
+        expect(nextSort('player1', 'desc', 'date')).toEqual({ column: 'date', direction: 'asc' });
+    });
+
+    test('switching column honours an explicit defaultDir', () => {
+        expect(nextSort(null, 'asc', 'equity', { defaultDir: 'desc' })).toEqual({ column: 'equity', direction: 'desc' });
+    });
+
+    test('same column ascending → descending', () => {
+        expect(nextSort('date', 'asc', 'date', { tristate: true })).toEqual({ column: 'date', direction: 'desc' });
+        expect(nextSort('equity', 'asc', 'equity')).toEqual({ column: 'equity', direction: 'desc' });
+    });
+
+    test('tristate: same column descending → unsorted', () => {
+        expect(nextSort('date', 'desc', 'date', { tristate: true })).toEqual({ column: null, direction: 'asc' });
+    });
+
+    test('two-state (no tristate): same column descending → ascending', () => {
+        expect(nextSort('equity', 'desc', 'equity')).toEqual({ column: 'equity', direction: 'asc' });
+    });
+});

--- a/frontend/src/components/AnalysisPanel.svelte
+++ b/frontend/src/components/AnalysisPanel.svelte
@@ -1,5 +1,6 @@
 <script>
     import { logger } from '../utils/logger.js';
+    import { nextSort } from '../utils/tableSort.js';
     import { analysisStore, selectedMoveStore } from '../stores/analysisStore'; // Import analysisStore and selectedMoveStore
     import { positionStore, matchContextStore } from '../stores/positionStore'; // Import positionStore and matchContextStore
     import { openPanels, PANEL } from '../stores/uiStore';
@@ -146,13 +147,12 @@
     });
 
     function handleSort(column) {
-        if (sortColumn === column) {
-            sortDirection = sortDirection === 'asc' ? 'desc' : 'asc';
-        } else {
-            sortColumn = column;
+        const next = nextSort(sortColumn, sortDirection, column, {
             // Default direction: desc for numeric, asc for string
-            sortDirection = sortableColumns[column].type === 'string' ? 'asc' : 'desc';
-        }
+            defaultDir: sortableColumns[column].type === 'string' ? 'asc' : 'desc'
+        });
+        sortColumn = next.column;
+        sortDirection = next.direction;
     }
 
     // Reactive sorted moves array

--- a/frontend/src/components/MatchPanel.svelte
+++ b/frontend/src/components/MatchPanel.svelte
@@ -1,6 +1,7 @@
 <script>
     import { logger } from '../utils/logger.js';
     import { sortMatches, toDateInputValue, formatDate, formatDiceShort, MATCH_STAT_ROWS } from '../utils/matchTable.js';
+    import { nextSort } from '../utils/tableSort.js';
     import { onMount, onDestroy, untrack } from 'svelte';
     import { get } from 'svelte/store';
     import {
@@ -309,18 +310,9 @@
 
     // --- Sorting helpers ---
     function handleSort(column) {
-        if (sortColumn === column) {
-            if (sortDirection === 'asc') {
-                sortDirection = 'desc';
-            } else {
-                // Reset sorting
-                sortColumn = null;
-                sortDirection = 'asc';
-            }
-        } else {
-            sortColumn = column;
-            sortDirection = 'asc';
-        }
+        const next = nextSort(sortColumn, sortDirection, column, { tristate: true });
+        sortColumn = next.column;
+        sortDirection = next.direction;
     }
 
     let sortedMatches = $derived.by(() => sortMatches(matches, sortColumn, sortDirection));

--- a/frontend/src/components/TournamentPanel.svelte
+++ b/frontend/src/components/TournamentPanel.svelte
@@ -1,5 +1,6 @@
 <script>
     import { logger } from '../utils/logger.js';
+    import { nextSort } from '../utils/tableSort.js';
     import { onMount, onDestroy } from 'svelte';
     import { dragReorder } from '../utils/dragReorder.js';
     import {
@@ -140,17 +141,9 @@
     }
 
     function handleSort(column) {
-        if (sortBy === column) {
-            if (sortOrder === 'asc') {
-                sortOrder = 'desc';
-            } else {
-                sortBy = null;
-                sortOrder = 'asc';
-            }
-        } else {
-            sortBy = column;
-            sortOrder = 'asc';
-        }
+        const next = nextSort(sortBy, sortOrder, column, { tristate: true });
+        sortBy = next.column;
+        sortOrder = next.direction;
         tournamentsStore.set(sortTournaments(tournaments));
     }
 

--- a/frontend/src/utils/tableSort.js
+++ b/frontend/src/utils/tableSort.js
@@ -1,0 +1,28 @@
+// Shared table-header sort-toggle logic, factored out of the per-panel
+// handleSort functions (MatchPanel, TournamentPanel, AnalysisPanel) which had
+// each reimplemented the same click-to-cycle behaviour.
+
+/**
+ * Compute the next sort state when a sortable column header is clicked.
+ *
+ * Clicking the currently-sorted column cycles its direction: ascending →
+ * descending, then (when `tristate`) back to unsorted (`column: null`), else
+ * back to ascending. Clicking a different column selects it with `defaultDir`.
+ *
+ * @param {string|null} curColumn   currently sorted column (null = unsorted)
+ * @param {'asc'|'desc'} curDirection current direction
+ * @param {string} column           the clicked column
+ * @param {{tristate?: boolean, defaultDir?: 'asc'|'desc'}} [opts]
+ *   tristate  — a third click on the same column clears the sort (default false)
+ *   defaultDir — direction when switching to a different column (default 'asc')
+ * @returns {{column: string|null, direction: 'asc'|'desc'}}
+ */
+export function nextSort(curColumn, curDirection, column, opts = {}) {
+    const { tristate = false, defaultDir = 'asc' } = opts;
+    if (curColumn === column) {
+        if (curDirection === 'asc') return { column, direction: 'desc' };
+        if (tristate) return { column: null, direction: 'asc' };
+        return { column, direction: 'asc' };
+    }
+    return { column, direction: defaultDir };
+}


### PR DESCRIPTION
## Suite — consolidation du tri de table

MatchPanel, TournamentPanel and AnalysisPanel each reimplemented the same click-to-cycle sort-header logic in their own `handleSort`. Extracted into one tested helper **`utils/tableSort.js` `nextSort(curColumn, curDirection, column, opts)`**:
- `opts.tristate` — after desc, a third click clears the sort (Match/Tournament); AnalysisPanel keeps the asc⇄desc two-state cycle.
- `opts.defaultDir` — direction when switching columns (Analysis: desc numeric / asc string; others asc).

Each panel's `handleSort` delegates to `nextSort` and assigns the result, **preserving its exact previous behaviour** (TournamentPanel keeps its `sortTournaments` side-effect; the `sortColumn/sortDirection` vs `sortBy/sortOrder` var names are unchanged at call sites). The ▲/▼ indicators stay inline (trivial, panel-specific markup).

**No behaviour change intended.** New `tableSort` unit tests pin the cycle (switch-column, asc→desc, tristate desc→unsorted, two-state desc→asc, explicit defaultDir).

✅ vitest **532 passed** · eslint + prettier clean · build green.

> ⚠️ **Held for GUI verification** before merge: please `wails dev` and click the sortable column headers in **Matches**, **Tournaments**, and the **Analysis** move table — confirm each cycles as before (Match/Tournament: asc → desc → unsorted; Analysis: asc ⇄ desc, with numeric columns starting desc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)