### PR TITLE
perf(search): ANALYZE on open when planner stats are missing

### DIFF
--- a/pkg/blunderdb/database/db.go
+++ b/pkg/blunderdb/database/db.go
@@ -3,6 +3,7 @@ package database
 import (
 	"context"
 	"database/sql"
+	"log/slog"
 	"sync"
 
 	_ "modernc.org/sqlite"
@@ -528,6 +529,31 @@ func (d *Database) OpenDatabase(path string) error {
 		return err
 	}
 
+	d.ensureSearchStats()
+
 	d.rebuildStore()
 	return nil
+}
+
+// ensureSearchStats runs a one-time ANALYZE when the opened database has no
+// query-planner statistics yet (sqlite_stat1 absent or empty). Without stats
+// SQLite mis-estimates selectivity for non-selective search filters — e.g. a
+// "win rate > 55% AND gammon > 20%" search that matches most rows is planned as
+// a single-column analysis-index scan followed by a TEMP B-TREE sort on p.id,
+// instead of scanning position in primary-key order (no sort). A full ANALYZE
+// fixes the plan (~4x on that case in the tournois benchmark); the stats persist
+// in the file, so later opens — and migrated databases, which already ANALYZE —
+// skip this. Non-fatal: search still works with stale/absent stats.
+func (d *Database) ensureSearchStats() {
+	if d.db == nil {
+		return
+	}
+	var n int
+	// Errors (e.g. sqlite_stat1 does not exist yet) count as "no stats".
+	if err := d.db.QueryRow(`SELECT count(*) FROM sqlite_stat1`).Scan(&n); err == nil && n > 0 {
+		return
+	}
+	if _, err := d.db.Exec(`ANALYZE`); err != nil {
+		slog.Warn("ANALYZE for search statistics failed", "err", err)
+	}
 }

--- a/pkg/blunderdb/database/search_stats_test.go
+++ b/pkg/blunderdb/database/search_stats_test.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestEnsureSearchStatsOnOpen verifies OpenDatabase populates query-planner
+// statistics (sqlite_stat1) for a database that has none yet, so non-selective
+// searches get a good plan instead of a temp-B-tree sort. ANALYZE is
+// results-neutral, so search correctness is covered by the existing search
+// tests; this only asserts the stats are created.
+func TestEnsureSearchStatsOnOpen(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "stats.db")
+
+	db := NewDatabase()
+	if err := db.SetupDatabase(path); err != nil {
+		t.Fatalf("SetupDatabase: %v", err)
+	}
+	if _, err := db.ImportXGMatch(filepath.Join("testdata", "test.xg")); err != nil {
+		db.Close()
+		t.Fatalf("ImportXGMatch: %v", err)
+	}
+	db.Close()
+
+	// Reopen: ensureSearchStats should run ANALYZE because the freshly-created
+	// file has no sqlite_stat1 rows yet.
+	db2 := NewDatabase()
+	if err := db2.OpenDatabase(path); err != nil {
+		t.Fatalf("OpenDatabase: %v", err)
+	}
+	defer db2.Close()
+
+	var n int
+	if err := db2.db.QueryRow(`SELECT count(*) FROM sqlite_stat1`).Scan(&n); err != nil {
+		t.Fatalf("query sqlite_stat1: %v", err)
+	}
+	if n == 0 {
+		t.Fatal("OpenDatabase did not populate sqlite_stat1 (ANALYZE missing)")
+	}
+}


### PR DESCRIPTION
First of the search-optimization plan. Without `sqlite_stat1` stats the planner mis-plans **non-selective** filters: "win>55% AND gammon>20%" (~79% of rows) → single-column analysis index + **TEMP B-TREE sort** on p.id instead of a PK-order `position` scan. A full `ANALYZE` flips the plan: that query **~132ms → ~34ms (~4×)**, identical results.

`ANALYZE` already runs after migrations but not when opening an already-current DB. `OpenDatabase` now calls `ensureSearchStats()` → `ANALYZE` once when `sqlite_stat1` is absent/empty; stats persist in the file (cheap repeat opens). (`PRAGMA optimize` is a no-op on a cold connection; sampled `analysis_limit` ANALYZE doesn't detect the non-selectivity — full ANALYZE is required.)

✅ `go build ./...`, vet, golangci-lint 0, `go test -race ./...` green; new `TestEnsureSearchStatsOnOpen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)