### PR TITLE
fix(search): decompress the analysis blob in the SQLite search path

### DIFF
--- a/pkg/blunderdb/database/search_analysis_decode_test.go
+++ b/pkg/blunderdb/database/search_analysis_decode_test.go
@@ -1,0 +1,41 @@
+package database
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestSearchMovePatternDecodesAnalysis guards the fix for the analysis blob
+// decode in the search path: analysis.data is stored zlib-compressed, so the
+// search must decompress it (engine.DecodeAnalysisFromStorage) before the
+// Go-side analysis filters can use it. A plain json.Unmarshal of the raw bytes
+// silently failed, leaving the decoded analysis nil and making the move-pattern
+// filter (and the mirror-search win/gammon fallbacks) match nothing.
+func TestSearchMovePatternDecodesAnalysis(t *testing.T) {
+	db := newTestDB(t)
+	if _, err := db.ImportXGMatch(filepath.Join("testdata", "test.xg")); err != nil {
+		t.Fatalf("ImportXGMatch: %v", err)
+	}
+
+	all, err := db.LoadPositionsByFilters(SearchFilters{Filter: emptyFilter()})
+	if err != nil {
+		t.Fatalf("baseline search: %v", err)
+	}
+	if len(all) == 0 {
+		t.Fatal("no positions imported")
+	}
+
+	// "/" appears in every checker-move notation, so a move-pattern search must
+	// match the checker-move positions — which is only possible if the
+	// compressed analysis blob was decoded.
+	mp, err := db.LoadPositionsByFilters(SearchFilters{Filter: emptyFilter(), MovePatternFilter: `m"/"`})
+	if err != nil {
+		t.Fatalf("move-pattern search: %v", err)
+	}
+	if len(mp) == 0 {
+		t.Fatal("move-pattern search returned 0 — analysis blob not decoded")
+	}
+	if len(mp) > len(all) {
+		t.Fatalf("move-pattern matches (%d) exceed total positions (%d)", len(mp), len(all))
+	}
+}

--- a/pkg/blunderdb/storage/sqlite/search_sqlite.go
+++ b/pkg/blunderdb/storage/sqlite/search_sqlite.go
@@ -3,7 +3,6 @@ package sqlite
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"iter"
 	"math"
@@ -299,8 +298,12 @@ func (s *searchStore) find(ctx context.Context, f domain.SearchFilters) ([]domai
 
 		var ana *domain.PositionAnalysis
 		if anaID.Valid && anaJSON.Valid && anaJSON.String != "" {
-			var a domain.PositionAnalysis
-			if jsonErr := json.Unmarshal([]byte(anaJSON.String), &a); jsonErr == nil {
+			// a.data is stored zlib-compressed (engine.EncodeAnalysisForStorage),
+			// so it must be decompressed before unmarshalling — a plain
+			// json.Unmarshal of the raw bytes silently fails (leaving ana nil),
+			// which broke the analysis-dependent Go-side filters (move pattern,
+			// and the win/gammon/equity fallbacks used by mirror search).
+			if a, decErr := engine.DecodeAnalysisFromStorage([]byte(anaJSON.String)); decErr == nil {
 				ana = &a
 			}
 		}


### PR DESCRIPTION
## Plan recherche #2 — correctness

The search selects `analysis.data` (stored **zlib-compressed** via `EncodeAnalysisForStorage`) but decoded it with a plain `json.Unmarshal` of the raw bytes → **always fails** on the zlib header → decoded `*PositionAnalysis` is **nil** for every result.

This silently broke the Go-side analysis filters that need the decoded blob:
- **move-pattern filter** (`m"…"`) matched nothing,
- the win/gammon/equity/move-error **fallbacks used by mirror search** returned nothing.

(Non-mirror win/gammon filters were fine — they use the denormalised SQL columns.)

Fix: decode via `engine.DecodeAnalysisFromStorage` (auto-detects zlib vs raw JSON), same helper the analysis store uses. **New regression test**: a move-pattern search now returns **300/543** matches on `test.xg` (was **0**). ✅ build, vet, golangci-lint 0, search/parity tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)