### PR TITLE
ci: deploy docs only on push and serialize gh-pages deploys

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -353,6 +353,12 @@ jobs:
 
   docs:
     runs-on: ubuntu-latest
+    # Serialize Pages deploys so bursts of merges (or a merge racing a tag
+    # push) queue instead of colliding on the gh-pages branch. cancel-in-progress
+    # stays false: every push should publish, none should be dropped.
+    concurrency:
+      group: gh-pages-deploy
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -395,6 +401,10 @@ jobs:
           echo '<!DOCTYPE html><html><head><meta http-equiv="refresh" content="0; url=en/"></head><body></body></html>' > ./doc/build/index.html
 
       - name: Deploy to GitHub Pages
+        # Only publish on push (main / tags); pull_request runs still build the
+        # docs above to catch breakage, but must not push to gh-pages — doing so
+        # both pollutes the published site and races the real push deploys.
+        if: github.event_name == 'push'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Corrige les reds CI récurrents sur le déploiement Pages

Le step **« Deploy to GitHub Pages »** du job `docs` n'avait **aucun gate d'événement** → il s'exécutait aussi sur `pull_request`, poussant les docs de la PR sur `gh-pages`. C'est incorrect (une PR ne doit pas publier le site) **et** ça entre en collision avec les déploiements de push : lors d'une rafale de merges, les push concurrents `peaceiris/actions-gh-pages` vers `gh-pages` se télescopent et un run échoue sur le step deploy alors que **tous les jobs code sont verts** (observé sur la PR #95 et le run main #97).

Deux correctifs :
- **Gate** `if: github.event_name == 'push'` sur le step deploy — les runs PR **construisent** toujours les docs (détection de casse) mais ne poussent jamais sur `gh-pages`.
- **Groupe de concurrence** `gh-pages-deploy` (`cancel-in-progress: false`) sur le job `docs` → les déploiements de push **font la queue** au lieu de se télescoper ; aucun n'est perdu.

Les jobs code n'ont jamais été affectés ; ceci supprime uniquement les reds parasites du step deploy. YAML validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)